### PR TITLE
Fix code scanning alert no. 23: Uncontrolled data used in path expression

### DIFF
--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -213,20 +213,33 @@ func fallbackToFrontend(c *gin.Context) {
 		c.JSON(http.StatusOK, newErrorResponse(errors.New("404 Not Found")))
 		return
 	}
+	const safeDirAdmin = "./admin-dist"
+	const safeDirUser = "user-dist"
+
 	if strings.HasPrefix(c.Request.URL.Path, "/dashboard") {
 		stripPath := strings.TrimPrefix(c.Request.URL.Path, "/dashboard")
-		localFilePath := filepath.Join("./admin-dist", stripPath)
-		if _, err := os.Stat(localFilePath); err == nil {
-			c.File(localFilePath)
+		localFilePath := filepath.Join(safeDirAdmin, stripPath)
+		absPath, err := filepath.Abs(localFilePath)
+		if err != nil || !strings.HasPrefix(absPath, safeDirAdmin) {
+			c.JSON(http.StatusBadRequest, newErrorResponse(errors.New("Invalid file path")))
 			return
 		}
-		c.File("admin-dist/index.html")
+		if _, err := os.Stat(absPath); err == nil {
+			c.File(absPath)
+			return
+		}
+		c.File(filepath.Join(safeDirAdmin, "index.html"))
 		return
 	}
-	localFilePath := filepath.Join("user-dist", c.Request.URL.Path)
-	if _, err := os.Stat(localFilePath); err == nil {
-		c.File(localFilePath)
+	localFilePath := filepath.Join(safeDirUser, c.Request.URL.Path)
+	absPath, err := filepath.Abs(localFilePath)
+	if err != nil || !strings.HasPrefix(absPath, safeDirUser) {
+		c.JSON(http.StatusBadRequest, newErrorResponse(errors.New("Invalid file path")))
 		return
 	}
-	c.File("user-dist/index.html")
+	if _, err := os.Stat(absPath); err == nil {
+		c.File(absPath)
+		return
+	}
+	c.File(filepath.Join(safeDirUser, "index.html"))
 }


### PR DESCRIPTION
Fixes [https://github.com/nezhahq/nezha/security/code-scanning/23](https://github.com/nezhahq/nezha/security/code-scanning/23)

To fix the problem, we need to validate the user input before using it to construct a file path. We should ensure that the resolved path is within a specific safe directory. This can be done by resolving the input with respect to that directory and then checking that the resulting path is still within it.

1. Define a constant for the safe directory.
2. Resolve the user-provided path with respect to the safe directory.
3. Check that the resolved path is within the safe directory.
4. If the path is valid, proceed with the file operations; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
