### PR TITLE
fix: use exec to properly handle container signals

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 printf "nameserver 127.0.0.11\nnameserver 8.8.4.4\nnameserver 223.5.5.5\n" > /etc/resolv.conf
-/dashboard/app
+exec /dashboard/app


### PR DESCRIPTION
- Replace direct command execution with exec to make app PID 1
- Ensures proper signal propagation in container
- Follows container best practices for process management

<img width="1656" alt="image" src="https://github.com/user-attachments/assets/56b20e8d-4cf5-4b0c-90a9-a75bde0a8645">
