### PR TITLE
update ws & settings api

### DIFF
--- a/cmd/dashboard/controller/setting.go
+++ b/cmd/dashboard/controller/setting.go
@@ -14,19 +14,25 @@ import (
 // @Security BearerAuth
 // @Tags common
 // @Produce json
-// @Success 200 {object} model.CommonResponse[model.Config]
+// @Success 200 {object} model.CommonResponse[model.SettingResponse]
 // @Router /setting [get]
-func listConfig(c *gin.Context) (model.Config, error) {
+func listConfig(c *gin.Context) (model.SettingResponse, error) {
 	_, isMember := c.Get(model.CtxKeyAuthorizedUser)
 	authorized := isMember // TODO || isViewPasswordVerfied
 
-	conf := *singleton.Conf
+	conf := model.SettingResponse{
+		Config:  *singleton.Conf,
+		Version: singleton.Version,
+	}
+
 	if !authorized {
-		conf = model.Config{
-			SiteName:            conf.SiteName,
-			Language:            conf.Language,
-			CustomCode:          conf.CustomCode,
-			CustomCodeDashboard: conf.CustomCodeDashboard,
+		conf = model.SettingResponse{
+			Config: model.Config{
+				SiteName:            conf.SiteName,
+				Language:            conf.Language,
+				CustomCode:          conf.CustomCode,
+				CustomCodeDashboard: conf.CustomCodeDashboard,
+			},
 		}
 	}
 
@@ -62,6 +68,7 @@ func updateConfig(c *gin.Context) (any, error) {
 	singleton.Conf.CustomCode = sf.CustomCode
 	singleton.Conf.CustomCodeDashboard = sf.CustomCodeDashboard
 	singleton.Conf.RealIPHeader = sf.RealIPHeader
+	singleton.Conf.TLS = sf.TLS
 
 	if err := singleton.Conf.Save(); err != nil {
 		return nil, newGormError("%v", err)

--- a/cmd/dashboard/controller/ws.go
+++ b/cmd/dashboard/controller/ws.go
@@ -155,7 +155,7 @@ func getServerStat(c *gin.Context, withPublicNote bool) ([]byte, error) {
 				Name:         server.Name,
 				PublicNote:   utils.IfOr(withPublicNote, server.PublicNote, ""),
 				DisplayIndex: server.DisplayIndex,
-				Host:         server.Host,
+				Host:         utils.IfOr(authorized, server.Host, server.Host.Filter()),
 				State:        server.State,
 				CountryCode:  countryCode,
 				LastActive:   server.LastActive,

--- a/model/host.go
+++ b/model/host.go
@@ -127,6 +127,21 @@ func (h *Host) PB() *pb.Host {
 	}
 }
 
+// Filter returns a new instance of Host with some fields redacted.
+func (h *Host) Filter() *Host {
+	return &Host{
+		Platform:       h.Platform,
+		CPU:            h.CPU,
+		MemTotal:       h.MemTotal,
+		DiskTotal:      h.DiskTotal,
+		SwapTotal:      h.SwapTotal,
+		Arch:           h.Arch,
+		Virtualization: h.Virtualization,
+		BootTime:       h.BootTime,
+		GPU:            h.GPU,
+	}
+}
+
 func PB2Host(h *pb.Host) Host {
 	return Host{
 		Platform:        h.GetPlatform(),

--- a/model/setting_api.go
+++ b/model/setting_api.go
@@ -12,6 +12,13 @@ type SettingForm struct {
 	CustomCodeDashboard         string `json:"custom_code_dashboard,omitempty" validate:"optional"`
 	RealIPHeader                string `json:"real_ip_header,omitempty" validate:"optional"` // 真实IP
 
+	TLS                         bool `json:"tls,omitempty" validate:"optional"`
 	EnableIPChangeNotification  bool `json:"enable_ip_change_notification,omitempty" validate:"optional"`
 	EnablePlainIPInNotification bool `json:"enable_plain_ip_in_notification,omitempty" validate:"optional"`
+}
+
+type SettingResponse struct {
+	Config
+
+	Version string `json:"version,omitempty"`
 }


### PR DESCRIPTION
设置 api 新增 TLS 修改与返回版本号功能（仅限登录）
ws 返回的 server 信息，未验证情况下不发送系统 / Agent 版本号