### PR TITLE
fix: dashboard 404

### DIFF
--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -299,7 +299,11 @@ func newCustomWriter(c *gin.Context, code int) *ginCustomWriter {
 }
 
 func (w *ginCustomWriter) WriteHeader(code int) {
-	w.ResponseWriter.WriteHeader(w.customCode)
+	if (w.customCode != 0) {
+		w.ResponseWriter.WriteHeader(w.customCode)
+		return
+	} 
+	w.ResponseWriter.WriteHeader(code)
 }
 
 func fileWithCustomStatusCode(c *gin.Context, filepath string, customCode int) {
@@ -335,8 +339,8 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/dashboard") {
 			stripPath := strings.TrimPrefix(c.Request.URL.Path, "/dashboard")
 			localFilePath := path.Join(singleton.Conf.AdminTemplate, stripPath)
-			statusCode := utils.IfOr(stripPath == "/", http.StatusOK, http.StatusNotFound)
-			if checkLocalFileOrFs(c, frontendDist, localFilePath, http.StatusOK) {
+			statusCode := utils.IfOr(stripPath == "/404", http.StatusNotFound, http.StatusOK)
+			if checkLocalFileOrFs(c, frontendDist, localFilePath, 0) {
 				return
 			}
 			if !checkLocalFileOrFs(c, frontendDist, singleton.Conf.AdminTemplate+"/index.html", statusCode) {
@@ -345,10 +349,10 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 			return
 		}
 		localFilePath := path.Join(singleton.Conf.UserTemplate, c.Request.URL.Path)
-		if checkLocalFileOrFs(c, frontendDist, localFilePath, http.StatusOK) {
+		if checkLocalFileOrFs(c, frontendDist, localFilePath, 0) {
 			return
 		}
-		statusCode := utils.IfOr(c.Request.URL.Path == "/", http.StatusOK, http.StatusNotFound)
+		statusCode := utils.IfOr(c.Request.URL.Path == "/404", http.StatusNotFound, http.StatusOK)
 		if !checkLocalFileOrFs(c, frontendDist, singleton.Conf.UserTemplate+"/index.html", statusCode) {
 			c.JSON(http.StatusNotFound, newErrorResponse(errors.New("404 Not Found")))
 		}


### PR DESCRIPTION
Currently, there is a bug where the dashboard page returns a 404 error.
![image](https://github.com/user-attachments/assets/c5b85186-8053-419f-b1b4-a58b12e62a13)

In order to return 404 https status code when the path is not defined in frontend router, we can fallback all request to frontend but add a /404 path to return 404 status code. And in frontend, we redirect all undefined paths to /404 on not-found page.

Related frontend PRs:
https://github.com/hamster1963/nezha-dash-v1/pull/26
https://github.com/nezhahq/admin-frontend/pull/92

Tested in my server

1. Dashboard 200 OK
![image](https://github.com/user-attachments/assets/637984a6-5a2a-4041-8ff2-9a42a95adbc5)

2. Dashboard 404
![image](https://github.com/user-attachments/assets/e40c11ef-c04b-427b-a51b-3844df8cc93c)

3. User page 404
![image](https://github.com/user-attachments/assets/be386278-b015-4673-b67e-216a320e6fb9)
