### PR TITLE
feat: option to force authorization for vistor routes

### DIFF
--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -60,7 +60,15 @@ func routers(r *gin.Engine, frontendDist fs.FS) {
 	api.POST("/login", authMiddleware.LoginHandler)
 	api.GET("/oauth2/:provider", commonHandler(oauth2redirect))
 
-	optionalAuth := api.Group("", optionalAuthMiddleware(authMiddleware))
+	fallbackAuthMw := fallbackAuthMiddleware(authMiddleware)
+	fallbackAuth := api.Group("", fallbackAuthMw)
+	fallbackAuth.GET("/setting", commonHandler(listConfig))
+	fallbackAuth.GET("/oauth2/callback", commonHandler(oauth2callback(authMiddleware)))
+
+	authMw := authMiddleware.MiddlewareFunc()
+	optionalAuthMw := utils.IfOr(singleton.Conf.ForceAuth, authMw, fallbackAuthMw)
+
+	optionalAuth := api.Group("", optionalAuthMw)
 	optionalAuth.GET("/ws/server", commonHandler(serverStream))
 	optionalAuth.GET("/server-group", commonHandler(listServerGroup))
 
@@ -68,11 +76,7 @@ func routers(r *gin.Engine, frontendDist fs.FS) {
 	optionalAuth.GET("/service/:id", commonHandler(listServiceHistory))
 	optionalAuth.GET("/service/server", commonHandler(listServerWithServices))
 
-	optionalAuth.GET("/oauth2/callback", commonHandler(oauth2callback(authMiddleware)))
-
-	optionalAuth.GET("/setting", commonHandler(listConfig))
-
-	auth := api.Group("", authMiddleware.MiddlewareFunc())
+	auth := api.Group("", authMw)
 
 	auth.GET("/refresh-token", authMiddleware.RefreshHandler)
 

--- a/cmd/dashboard/controller/jwt.go
+++ b/cmd/dashboard/controller/jwt.go
@@ -148,7 +148,7 @@ func refreshResponse(c *gin.Context, code int, token string, expire time.Time) {
 	})
 }
 
-func optionalAuthMiddleware(mw *jwt.GinJWTMiddleware) func(c *gin.Context) {
+func fallbackAuthMiddleware(mw *jwt.GinJWTMiddleware) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		claims, err := mw.GetClaimsFromJWT(c)
 		if err != nil {

--- a/model/config.go
+++ b/model/config.go
@@ -48,7 +48,8 @@ type Config struct {
 	ListenHost     string `mapstructure:"listen_host" json:"listen_host,omitempty"`
 	InstallHost    string `mapstructure:"install_host" json:"install_host,omitempty"`
 	TLS            bool   `mapstructure:"tls" json:"tls,omitempty"`
-	Location       string `mapstructure:"location" json:"location,omitempty"` // 时区，默认为 Asia/Shanghai
+	Location       string `mapstructure:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
+	ForceAuth      bool   `mapstructure:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
 
 	EnablePlainIPInNotification bool `mapstructure:"enable_plain_ip_in_notification" json:"enable_plain_ip_in_notification,omitempty"` // 通知信息IP不打码
 


### PR DESCRIPTION
新增 `forceauth` 选项，只能手动配置。
开启后，所有访客 API（例如查看服务器，在线用户等）均需要强制认证，登录相关 API 不受影响。