### PR TITLE
ddns: allow overriding domains per configuration

### DIFF
--- a/cmd/dashboard/controller/server.go
+++ b/cmd/dashboard/controller/server.go
@@ -84,11 +84,19 @@ func updateServer(c *gin.Context) (any, error) {
 	s.HideForGuest = sf.HideForGuest
 	s.EnableDDNS = sf.EnableDDNS
 	s.DDNSProfiles = sf.DDNSProfiles
+	s.OverrideDDNSDomains = sf.OverrideDDNSDomains
+
 	ddnsProfilesRaw, err := utils.Json.Marshal(s.DDNSProfiles)
 	if err != nil {
 		return nil, err
 	}
 	s.DDNSProfilesRaw = string(ddnsProfilesRaw)
+
+	overrideDomainsRaw, err := utils.Json.Marshal(sf.OverrideDDNSDomains)
+	if err != nil {
+		return nil, err
+	}
+	s.OverrideDDNSDomainsRaw = string(overrideDomainsRaw)
 
 	if err := singleton.DB.Save(&s).Error; err != nil {
 		return nil, newGormError("%v", err)

--- a/model/server.go
+++ b/model/server.go
@@ -14,16 +14,18 @@ import (
 type Server struct {
 	Common
 
-	Name            string `json:"name"`
-	UUID            string `json:"uuid,omitempty" gorm:"unique"`
-	Note            string `json:"note,omitempty"`           // 管理员可见备注
-	PublicNote      string `json:"public_note,omitempty"`    // 公开备注
-	DisplayIndex    int    `json:"display_index"`            // 展示排序，越大越靠前
-	HideForGuest    bool   `json:"hide_for_guest,omitempty"` // 对游客隐藏
-	EnableDDNS      bool   `json:"enable_ddns,omitempty"`    // 启用DDNS
-	DDNSProfilesRaw string `gorm:"default:'[]';column:ddns_profiles_raw" json:"-"`
+	Name                   string `json:"name"`
+	UUID                   string `json:"uuid,omitempty" gorm:"unique"`
+	Note                   string `json:"note,omitempty"`           // 管理员可见备注
+	PublicNote             string `json:"public_note,omitempty"`    // 公开备注
+	DisplayIndex           int    `json:"display_index"`            // 展示排序，越大越靠前
+	HideForGuest           bool   `json:"hide_for_guest,omitempty"` // 对游客隐藏
+	EnableDDNS             bool   `json:"enable_ddns,omitempty"`    // 启用DDNS
+	DDNSProfilesRaw        string `gorm:"default:'[]';column:ddns_profiles_raw" json:"-"`
+	OverrideDDNSDomainsRaw string `gorm:"default:'{}';column:override_ddns_domains_raw" json:"-"`
 
-	DDNSProfiles []uint64 `gorm:"-" json:"ddns_profiles,omitempty" validate:"optional"` // DDNS配置
+	DDNSProfiles        []uint64            `gorm:"-" json:"ddns_profiles,omitempty" validate:"optional"` // DDNS配置
+	OverrideDDNSDomains map[uint64][]string `gorm:"-" json:"override_ddns_domains,omitempty" validate:"optional"`
 
 	Host       *Host      `gorm:"-" json:"host,omitempty"`
 	State      *HostState `gorm:"-" json:"state,omitempty"`
@@ -49,6 +51,12 @@ func (s *Server) CopyFromRunningServer(old *Server) {
 func (s *Server) AfterFind(tx *gorm.DB) error {
 	if s.DDNSProfilesRaw != "" {
 		if err := utils.Json.Unmarshal([]byte(s.DDNSProfilesRaw), &s.DDNSProfiles); err != nil {
+			log.Println("NEZHA>> Server.AfterFind:", err)
+			return nil
+		}
+	}
+	if s.OverrideDDNSDomainsRaw != "" {
+		if err := utils.Json.Unmarshal([]byte(s.OverrideDDNSDomainsRaw), &s.OverrideDDNSDomains); err != nil {
 			log.Println("NEZHA>> Server.AfterFind:", err)
 			return nil
 		}

--- a/model/server_api.go
+++ b/model/server_api.go
@@ -21,13 +21,14 @@ type StreamServerData struct {
 }
 
 type ServerForm struct {
-	Name         string   `json:"name,omitempty"`
-	Note         string   `json:"note,omitempty" validate:"optional"`                   // 管理员可见备注
-	PublicNote   string   `json:"public_note,omitempty" validate:"optional"`            // 公开备注
-	DisplayIndex int      `json:"display_index,omitempty" default:"0"`                  // 展示排序，越大越靠前
-	HideForGuest bool     `json:"hide_for_guest,omitempty" validate:"optional"`         // 对游客隐藏
-	EnableDDNS   bool     `json:"enable_ddns,omitempty" validate:"optional"`            // 启用DDNS
-	DDNSProfiles []uint64 `gorm:"-" json:"ddns_profiles,omitempty" validate:"optional"` // DDNS配置
+	Name                string              `json:"name,omitempty"`
+	Note                string              `json:"note,omitempty" validate:"optional"`           // 管理员可见备注
+	PublicNote          string              `json:"public_note,omitempty" validate:"optional"`    // 公开备注
+	DisplayIndex        int                 `json:"display_index,omitempty" default:"0"`          // 展示排序，越大越靠前
+	HideForGuest        bool                `json:"hide_for_guest,omitempty" validate:"optional"` // 对游客隐藏
+	EnableDDNS          bool                `json:"enable_ddns,omitempty" validate:"optional"`    // 启用DDNS
+	DDNSProfiles        []uint64            `json:"ddns_profiles,omitempty" validate:"optional"`  // DDNS配置
+	OverrideDDNSDomains map[uint64][]string `json:"override_ddns_domains,omitempty" validate:"optional"`
 }
 
 type ForceUpdateResponse struct {

--- a/service/rpc/nezha.go
+++ b/service/rpc/nezha.go
@@ -231,11 +231,13 @@ func (s *NezhaHandler) ReportGeoIP(c context.Context, r *pb.GeoIP) (*pb.GeoIP, e
 		(server.GeoIP == nil || server.GeoIP.IP != geoip.IP) {
 		ipv4 := geoip.IP.IPv4Addr
 		ipv6 := geoip.IP.IPv6Addr
+
 		providers, err := singleton.GetDDNSProvidersFromProfiles(server.DDNSProfiles, &ddns.IP{Ipv4Addr: ipv4, Ipv6Addr: ipv6})
 		if err == nil {
 			for _, provider := range providers {
+				domains := server.OverrideDDNSDomains[provider.GetProfileID()]
 				go func(provider *ddns.Provider) {
-					provider.UpdateDomain(context.Background())
+					provider.UpdateDomain(context.Background(), domains...)
 				}(provider)
 			}
 		} else {


### PR DESCRIPTION
`Server` 新增 `OverrideDDNSDomains` 字段，可以覆盖使用的 DDNS 配置的域名。