### PR TITLE
feat: update to go1.24 & support listening https

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
     flags:
       - -trimpath
       - -buildvcs=false
+    tags:
+      - go_json
     goos:
       - linux
     goarch:
@@ -31,6 +33,8 @@ builds:
     flags:
       - -trimpath
       - -buildvcs=false
+    tags:
+      - go_json
     goos:
       - linux
     goarch:
@@ -48,6 +52,8 @@ builds:
     flags:
       - -trimpath
       - -buildvcs=false
+    tags:
+      - go_json
     goos:
       - linux
     goarch:
@@ -65,6 +71,8 @@ builds:
     flags:
       - -trimpath
       - -buildvcs=false
+    tags:
+      - go_json
     goos:
       - windows
     goarch:

--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -175,10 +175,10 @@ type pHandlerFunc[S ~[]E, E any] func(c *gin.Context) (*model.Value[S], error)
 // gorm errors here instead
 type gormError struct {
 	msg string
-	a   []interface{}
+	a   []any
 }
 
-func newGormError(format string, args ...interface{}) error {
+func newGormError(format string, args ...any) error {
 	return &gormError{
 		msg: format,
 		a:   args,
@@ -191,10 +191,10 @@ func (ge *gormError) Error() string {
 
 type wsError struct {
 	msg string
-	a   []interface{}
+	a   []any
 }
 
-func newWsError(format string, args ...interface{}) error {
+func newWsError(format string, args ...any) error {
 	return &wsError{
 		msg: format,
 		a:   args,

--- a/cmd/dashboard/controller/fm.go
+++ b/cmd/dashboard/controller/fm.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/goccy/go-json"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-uuid"
 
 	"github.com/nezhahq/nezha/model"
-	"github.com/nezhahq/nezha/pkg/utils"
 	"github.com/nezhahq/nezha/pkg/websocketx"
 	"github.com/nezhahq/nezha/proto"
 	"github.com/nezhahq/nezha/service/rpc"
@@ -48,7 +48,7 @@ func createFM(c *gin.Context) (*model.CreateFMResponse, error) {
 
 	rpc.NezhaHandlerSingleton.CreateStream(streamId)
 
-	fmData, _ := utils.Json.Marshal(&model.TaskFM{
+	fmData, _ := json.Marshal(&model.TaskFM{
 		StreamID: streamId,
 	})
 	if err := server.TaskStream.Send(&proto.Task{

--- a/cmd/dashboard/controller/jwt.go
+++ b/cmd/dashboard/controller/jwt.go
@@ -48,8 +48,8 @@ func initParams() *jwt.GinJWTMiddleware {
 	}
 }
 
-func payloadFunc() func(data interface{}) jwt.MapClaims {
-	return func(data interface{}) jwt.MapClaims {
+func payloadFunc() func(data any) jwt.MapClaims {
+	return func(data any) jwt.MapClaims {
 		if v, ok := data.(string); ok {
 			return jwt.MapClaims{
 				model.CtxKeyAuthorizedUser: v,
@@ -59,8 +59,8 @@ func payloadFunc() func(data interface{}) jwt.MapClaims {
 	}
 }
 
-func identityHandler() func(c *gin.Context) interface{} {
-	return func(c *gin.Context) interface{} {
+func identityHandler() func(c *gin.Context) any {
+	return func(c *gin.Context) any {
 		claims := jwt.ExtractClaims(c)
 		userId := claims[model.CtxKeyAuthorizedUser].(string)
 		var user model.User
@@ -80,8 +80,8 @@ func identityHandler() func(c *gin.Context) interface{} {
 // @Produce json
 // @Success 200 {object} model.CommonResponse[model.LoginResponse]
 // @Router /login [post]
-func authenticator() func(c *gin.Context) (interface{}, error) {
-	return func(c *gin.Context) (interface{}, error) {
+func authenticator() func(c *gin.Context) (any, error) {
+	return func(c *gin.Context) (any, error) {
 		var loginVals model.LoginRequest
 		if err := c.ShouldBind(&loginVals); err != nil {
 			return "", jwt.ErrMissingLoginValues
@@ -113,8 +113,8 @@ func authenticator() func(c *gin.Context) (interface{}, error) {
 	}
 }
 
-func authorizator() func(data interface{}, c *gin.Context) bool {
-	return func(data interface{}, c *gin.Context) bool {
+func authorizator() func(data any, c *gin.Context) bool {
+	return func(data any, c *gin.Context) bool {
 		_, ok := data.(*model.User)
 		return ok
 	}

--- a/cmd/dashboard/controller/jwt.go
+++ b/cmd/dashboard/controller/jwt.go
@@ -1,12 +1,12 @@
 package controller
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
 	jwt "github.com/appleboy/gin-jwt/v2"
 	"github.com/gin-gonic/gin"
+	"github.com/goccy/go-json"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 

--- a/cmd/dashboard/controller/server.go
+++ b/cmd/dashboard/controller/server.go
@@ -281,10 +281,7 @@ func setServerConfig(c *gin.Context) (*model.ServerTaskResponse, error) {
 	var respMu sync.Mutex
 
 	for i := 0; i < len(servers); i += 10 {
-		end := i + 10
-		if end > len(servers) {
-			end = len(servers)
-		}
+		end := min(i+10, len(servers))
 		group := servers[i:end]
 
 		wg.Add(1)

--- a/cmd/dashboard/controller/server.go
+++ b/cmd/dashboard/controller/server.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/goccy/go-json"
 	"github.com/jinzhu/copier"
 	"gorm.io/gorm"
 
 	"github.com/nezhahq/nezha/model"
-	"github.com/nezhahq/nezha/pkg/utils"
 	pb "github.com/nezhahq/nezha/proto"
 	"github.com/nezhahq/nezha/service/singleton"
 )
@@ -81,13 +81,13 @@ func updateServer(c *gin.Context) (any, error) {
 	s.DDNSProfiles = sf.DDNSProfiles
 	s.OverrideDDNSDomains = sf.OverrideDDNSDomains
 
-	ddnsProfilesRaw, err := utils.Json.Marshal(s.DDNSProfiles)
+	ddnsProfilesRaw, err := json.Marshal(s.DDNSProfiles)
 	if err != nil {
 		return nil, err
 	}
 	s.DDNSProfilesRaw = string(ddnsProfilesRaw)
 
-	overrideDomainsRaw, err := utils.Json.Marshal(sf.OverrideDDNSDomains)
+	overrideDomainsRaw, err := json.Marshal(sf.OverrideDDNSDomains)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dashboard/controller/service.go
+++ b/cmd/dashboard/controller/service.go
@@ -25,7 +25,7 @@ import (
 // @Success 200 {object} model.CommonResponse[model.ServiceResponse]
 // @Router /service [get]
 func showService(c *gin.Context) (*model.ServiceResponse, error) {
-	res, err, _ := requestGroup.Do("list-service", func() (interface{}, error) {
+	res, err, _ := requestGroup.Do("list-service", func() (any, error) {
 		singleton.AlertsLock.RLock()
 		defer singleton.AlertsLock.RUnlock()
 		stats := singleton.ServiceSentinelShared.CopyStats()
@@ -41,8 +41,8 @@ func showService(c *gin.Context) (*model.ServiceResponse, error) {
 	}
 
 	return &model.ServiceResponse{
-		Services:           res.([]interface{})[0].(map[uint64]model.ServiceResponseItem),
-		CycleTransferStats: res.([]interface{})[1].(map[uint64]model.CycleTransferStats),
+		Services:           res.([]any)[0].(map[uint64]model.ServiceResponseItem),
+		CycleTransferStats: res.([]any)[1].(map[uint64]model.CycleTransferStats),
 	}, nil
 }
 

--- a/cmd/dashboard/controller/setting.go
+++ b/cmd/dashboard/controller/setting.go
@@ -45,7 +45,7 @@ func listConfig(c *gin.Context) (model.SettingResponse[any], error) {
 			Oauth2Providers:     config.Oauth2Providers,
 		}
 		if authorized {
-			configForGuests.TLS = singleton.Conf.TLS
+			configForGuests.AgentTLS = singleton.Conf.AgentTLS
 			configForGuests.InstallHost = singleton.Conf.InstallHost
 		}
 		conf = model.SettingResponse[any]{
@@ -98,7 +98,7 @@ func updateConfig(c *gin.Context) (any, error) {
 	singleton.Conf.CustomCode = sf.CustomCode
 	singleton.Conf.CustomCodeDashboard = sf.CustomCodeDashboard
 	singleton.Conf.RealIPHeader = sf.RealIPHeader
-	singleton.Conf.TLS = sf.TLS
+	singleton.Conf.AgentTLS = sf.AgentTLS
 	singleton.Conf.UserTemplate = sf.UserTemplate
 
 	if err := singleton.Conf.Save(); err != nil {

--- a/cmd/dashboard/controller/setting.go
+++ b/cmd/dashboard/controller/setting.go
@@ -17,9 +17,9 @@ import (
 // @Security BearerAuth
 // @Tags common
 // @Produce json
-// @Success 200 {object} model.CommonResponse[model.SettingResponse[model.Config]]
+// @Success 200 {object} model.CommonResponse[model.SettingResponse]
 // @Router /setting [get]
-func listConfig(c *gin.Context) (model.SettingResponse[any], error) {
+func listConfig(c *gin.Context) (*model.SettingResponse, error) {
 	u, authorized := c.Get(model.CtxKeyAuthorizedUser)
 	var isAdmin bool
 	if authorized {
@@ -30,30 +30,29 @@ func listConfig(c *gin.Context) (model.SettingResponse[any], error) {
 	config := *singleton.Conf
 	config.Language = strings.Replace(config.Language, "_", "-", -1)
 
-	conf := model.SettingResponse[any]{
-		Config:            config,
+	conf := model.SettingResponse{
+		Config: model.Setting{
+			ConfigForGuests: config.ConfigForGuests,
+			ConfigDashboard: config.ConfigDashboard,
+		},
 		Version:           singleton.Version,
 		FrontendTemplates: singleton.FrontendTemplates,
 	}
 
 	if !authorized || !isAdmin {
-		configForGuests := model.ConfigForGuests{
-			Language:            config.Language,
-			SiteName:            config.SiteName,
-			CustomCode:          config.CustomCode,
-			CustomCodeDashboard: config.CustomCodeDashboard,
-			Oauth2Providers:     config.Oauth2Providers,
-		}
+		configForGuests := config.ConfigForGuests
 		if authorized {
 			configForGuests.AgentTLS = singleton.Conf.AgentTLS
 			configForGuests.InstallHost = singleton.Conf.InstallHost
 		}
-		conf = model.SettingResponse[any]{
-			Config: configForGuests,
+		conf = model.SettingResponse{
+			Config: model.Setting{
+				ConfigForGuests: configForGuests,
+			},
 		}
 	}
 
-	return conf, nil
+	return &conf, nil
 }
 
 // Edit config

--- a/cmd/dashboard/controller/terminal.go
+++ b/cmd/dashboard/controller/terminal.go
@@ -4,11 +4,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/goccy/go-json"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-uuid"
 
 	"github.com/nezhahq/nezha/model"
-	"github.com/nezhahq/nezha/pkg/utils"
 	"github.com/nezhahq/nezha/pkg/websocketx"
 	"github.com/nezhahq/nezha/proto"
 	"github.com/nezhahq/nezha/service/rpc"
@@ -46,7 +46,7 @@ func createTerminal(c *gin.Context) (*model.CreateTerminalResponse, error) {
 
 	rpc.NezhaHandlerSingleton.CreateStream(streamId)
 
-	terminalData, _ := utils.Json.Marshal(&model.TerminalTask{
+	terminalData, _ := json.Marshal(&model.TerminalTask{
 		StreamID: streamId,
 	})
 	if err := server.TaskStream.Send(&proto.Task{

--- a/cmd/dashboard/controller/ws.go
+++ b/cmd/dashboard/controller/ws.go
@@ -158,7 +158,7 @@ func serverStream(c *gin.Context) (any, error) {
 var requestGroup singleflight.Group
 
 func getServerStat(withPublicNote, authorized bool) ([]byte, error) {
-	v, err, _ := requestGroup.Do(fmt.Sprintf("serverStats::%t", authorized), func() (interface{}, error) {
+	v, err, _ := requestGroup.Do(fmt.Sprintf("serverStats::%t", authorized), func() (any, error) {
 		var serverList []*model.Server
 		if authorized {
 			serverList = singleton.ServerShared.GetSortedList()

--- a/cmd/dashboard/controller/ws.go
+++ b/cmd/dashboard/controller/ws.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gin-gonic/gin"
+	"github.com/goccy/go-json"
 	"github.com/gorilla/websocket"
 	"github.com/hashicorp/go-uuid"
 	"golang.org/x/sync/singleflight"
@@ -183,7 +184,7 @@ func getServerStat(withPublicNote, authorized bool) ([]byte, error) {
 			})
 		}
 
-		return utils.Json.Marshal(model.StreamServerData{
+		return json.Marshal(model.StreamServerData{
 			Now:     time.Now().Unix() * 1000,
 			Online:  singleton.GetOnlineUserCount(),
 			Servers: servers,

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -135,6 +135,7 @@ func main() {
 		Handler:           muxHandler,
 		ReadHeaderTimeout: time.Second * 5,
 	}
+	muxServer.Protocols = new(http.Protocols)
 	muxServer.Protocols.SetHTTP1(true)
 	if singleton.Conf.EnableTLS {
 		muxServer.Protocols.SetHTTP2(true)

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -169,7 +170,7 @@ func ServeNAT(w http.ResponseWriter, r *http.Request, natConfig *model.NAT) {
 	rpcService.NezhaHandlerSingleton.CreateStream(streamId)
 	defer rpcService.NezhaHandlerSingleton.CloseStream(streamId)
 
-	taskData, err := utils.Json.Marshal(model.TaskNAT{
+	taskData, err := json.Marshal(model.TaskNAT{
 		StreamID: streamId,
 		Host:     natConfig.Host,
 	})

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -2,13 +2,13 @@ package rpc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/netip"
 	"time"
 
+	"github.com/goccy/go-json"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"

--- a/cmd/dashboard/rpc/rpc.go
+++ b/cmd/dashboard/rpc/rpc.go
@@ -28,7 +28,7 @@ func ServeRPC() *grpc.Server {
 	return server
 }
 
-func waf(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func waf(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	realip, _ := ctx.Value(model.CtxKeyRealIP{}).(string)
 	if err := model.CheckIP(singleton.DB, realip); err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func waf(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handl
 	return handler(ctx, req)
 }
 
-func getRealIp(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func getRealIp(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	var ip, connectingIp string
 	p, ok := peer.FromContext(ctx)
 	if ok {
@@ -163,7 +163,7 @@ func ServeNAT(w http.ResponseWriter, r *http.Request, natConfig *model.NAT) {
 	streamId, err := uuid.GenerateUUID()
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(fmt.Sprintf("stream id error: %v", err)))
+		w.Write(fmt.Appendf(nil, "stream id error: %v", err))
 		return
 	}
 
@@ -176,7 +176,7 @@ func ServeNAT(w http.ResponseWriter, r *http.Request, natConfig *model.NAT) {
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(fmt.Sprintf("task data error: %v", err)))
+		w.Write(fmt.Appendf(nil, "task data error: %v", err))
 		return
 	}
 
@@ -185,20 +185,20 @@ func ServeNAT(w http.ResponseWriter, r *http.Request, natConfig *model.NAT) {
 		Data: string(taskData),
 	}); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(fmt.Sprintf("send task error: %v", err)))
+		w.Write(fmt.Appendf(nil, "send task error: %v", err))
 		return
 	}
 
 	wWrapped, err := utils.NewRequestWrapper(r, w)
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(fmt.Sprintf("request wrapper error: %v", err)))
+		w.Write(fmt.Appendf(nil, "request wrapper error: %v", err))
 		return
 	}
 
 	if err := rpcService.NezhaHandlerSingleton.UserConnected(streamId, wWrapped); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte(fmt.Sprintf("user connected error: %v", err)))
+		w.Write(fmt.Appendf(nil, "user connected error: %v", err))
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nezhahq/nezha
 
-go 1.23.6
+go 1.24.0
 
 require (
 	github.com/appleboy/gin-jwt/v2 v2.10.1
@@ -8,10 +8,10 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/gin-contrib/pprof v1.5.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/goccy/go-json v0.10.5
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/jinzhu/copier v0.4.0
-	github.com/json-iterator/go v1.1.12
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/env v1.0.0
 	github.com/knadh/koanf/providers/file v1.1.2
@@ -57,11 +57,11 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.25.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
-	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
 	github.com/gin-contrib/pprof v1.5.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/goccy/go-json v0.10.5
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/jinzhu/copier v0.4.0
-	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/env v1.0.0
 	github.com/knadh/koanf/providers/file v1.1.2
 	github.com/knadh/koanf/v2 v2.1.2
@@ -38,6 +38,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -56,7 +57,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.25.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/jinzhu/copier v0.4.0
+	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/env v1.0.0
 	github.com/knadh/koanf/providers/file v1.1.2
 	github.com/knadh/koanf/v2 v2.1.2
@@ -38,7 +39,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQg
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -84,8 +85,6 @@ github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kK
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
-github.com/knadh/koanf/parsers/yaml v0.1.0 h1:ZZ8/iGfRLvKSaMEECEBPM1HQslrZADk8fP1XFUxVI5w=
-github.com/knadh/koanf/parsers/yaml v0.1.0/go.mod h1:cvbUDC7AL23pImuQP0oRw/hPuccrNBS2bps8asS0CwY=
 github.com/knadh/koanf/providers/env v1.0.0 h1:ufePaI9BnWH+ajuxGGiJ8pdTG0uLEUWC7/HDDPGLah0=
 github.com/knadh/koanf/providers/env v1.0.0/go.mod h1:mzFyRZueYhb37oPmC1HAv/oGEEuyvJDA98r3XAa8Gak=
 github.com/knadh/koanf/providers/file v1.1.2 h1:aCC36YGOgV5lTtAFz2qkgtWdeQsgfxUkxDOe+2nQY3w=
@@ -248,3 +247,5 @@ gorm.io/driver/sqlite v1.5.7/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDa
 gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
 gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQg
 github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -85,6 +84,8 @@ github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kK
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
+github.com/knadh/koanf/parsers/yaml v0.1.0 h1:ZZ8/iGfRLvKSaMEECEBPM1HQslrZADk8fP1XFUxVI5w=
+github.com/knadh/koanf/parsers/yaml v0.1.0/go.mod h1:cvbUDC7AL23pImuQP0oRw/hPuccrNBS2bps8asS0CwY=
 github.com/knadh/koanf/providers/env v1.0.0 h1:ufePaI9BnWH+ajuxGGiJ8pdTG0uLEUWC7/HDDPGLah0=
 github.com/knadh/koanf/providers/env v1.0.0/go.mod h1:mzFyRZueYhb37oPmC1HAv/oGEEuyvJDA98r3XAa8Gak=
 github.com/knadh/koanf/providers/file v1.1.2 h1:aCC36YGOgV5lTtAFz2qkgtWdeQsgfxUkxDOe+2nQY3w=
@@ -247,5 +248,3 @@ gorm.io/driver/sqlite v1.5.7/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDa
 gorm.io/gorm v1.25.12 h1:I0u8i2hWQItBq1WfE0o2+WuL9+8L21K9e2HHSTE/0f8=
 gorm.io/gorm v1.25.12/go.mod h1:xh7N7RHfYlNc5EmcI/El95gXusucDrQnHXe0+CgWcLQ=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
-sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
-sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/model/alertrule.go
+++ b/model/alertrule.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/nezhahq/nezha/pkg/utils"
+	"github.com/goccy/go-json"
 	"gorm.io/gorm"
 )
 
@@ -25,17 +25,17 @@ type AlertRule struct {
 }
 
 func (r *AlertRule) BeforeSave(tx *gorm.DB) error {
-	if data, err := utils.Json.Marshal(r.Rules); err != nil {
+	if data, err := json.Marshal(r.Rules); err != nil {
 		return err
 	} else {
 		r.RulesRaw = string(data)
 	}
-	if data, err := utils.Json.Marshal(r.FailTriggerTasks); err != nil {
+	if data, err := json.Marshal(r.FailTriggerTasks); err != nil {
 		return err
 	} else {
 		r.FailTriggerTasksRaw = string(data)
 	}
-	if data, err := utils.Json.Marshal(r.RecoverTriggerTasks); err != nil {
+	if data, err := json.Marshal(r.RecoverTriggerTasks); err != nil {
 		return err
 	} else {
 		r.RecoverTriggerTasksRaw = string(data)
@@ -45,13 +45,13 @@ func (r *AlertRule) BeforeSave(tx *gorm.DB) error {
 
 func (r *AlertRule) AfterFind(tx *gorm.DB) error {
 	var err error
-	if err = utils.Json.Unmarshal([]byte(r.RulesRaw), &r.Rules); err != nil {
+	if err = json.Unmarshal([]byte(r.RulesRaw), &r.Rules); err != nil {
 		return err
 	}
-	if err = utils.Json.Unmarshal([]byte(r.FailTriggerTasksRaw), &r.FailTriggerTasks); err != nil {
+	if err = json.Unmarshal([]byte(r.FailTriggerTasksRaw), &r.FailTriggerTasks); err != nil {
 		return err
 	}
-	if err = utils.Json.Unmarshal([]byte(r.RecoverTriggerTasksRaw), &r.RecoverTriggerTasks); err != nil {
+	if err = json.Unmarshal([]byte(r.RecoverTriggerTasksRaw), &r.RecoverTriggerTasks); err != nil {
 		return err
 	}
 	return nil

--- a/model/common.go
+++ b/model/common.go
@@ -77,7 +77,7 @@ func SearchByIDCtx[S ~[]E, E CommonInterface](c *gin.Context, x S) S {
 		return any(l).(S)
 	default:
 		var s S
-		for _, idStr := range strings.Split(c.Query("id"), ",") {
+		for idStr := range strings.SplitSeq(c.Query("id"), ",") {
 			id, err := strconv.ParseUint(idStr, 10, 64)
 			if err != nil {
 				continue
@@ -93,7 +93,7 @@ func searchByIDCtxServer(c *gin.Context, x []*Server) []*Server {
 	list1, list2 := SplitList(x)
 
 	var clist1, clist2 []*Server
-	for _, idStr := range strings.Split(c.Query("id"), ",") {
+	for idStr := range strings.SplitSeq(c.Query("id"), ",") {
 		id, err := strconv.ParseUint(idStr, 10, 64)
 		if err != nil {
 			continue

--- a/model/config.go
+++ b/model/config.go
@@ -165,9 +165,8 @@ func (c *Config) Read(path string, frontendTemplates []FrontendTemplate) error {
 // updateIgnoredIPNotificationID 更新用于判断服务器ID是否属于特定服务器的map
 func (c *Config) updateIgnoredIPNotificationID() {
 	c.IgnoredIPNotificationServerIDs = make(map[uint64]bool)
-	splitedIDs := strings.Split(c.IgnoredIPNotification, ",")
-	for i := 0; i < len(splitedIDs); i++ {
-		id, _ := strconv.ParseUint(splitedIDs[i], 10, 64)
+	for splitedID := range strings.SplitSeq(c.IgnoredIPNotification, ",") {
+		id, _ := strconv.ParseUint(splitedID, 10, 64)
 		if id > 0 {
 			c.IgnoredIPNotificationServerIDs[id] = true
 		}

--- a/model/config.go
+++ b/model/config.go
@@ -31,7 +31,7 @@ type ConfigForGuests struct {
 	Oauth2Providers     []string `json:"oauth2_providers,omitempty"`
 
 	InstallHost string `json:"install_host,omitempty"`
-	TLS         bool   `json:"tls,omitempty"`
+	AgentTLS    bool   `json:"tls,omitempty"`
 }
 
 type Config struct {
@@ -47,7 +47,7 @@ type Config struct {
 	ListenPort     uint   `mapstructure:"listen_port" json:"listen_port,omitempty"`
 	ListenHost     string `mapstructure:"listen_host" json:"listen_host,omitempty"`
 	InstallHost    string `mapstructure:"install_host" json:"install_host,omitempty"`
-	TLS            bool   `mapstructure:"tls" json:"tls,omitempty"`
+	AgentTLS       bool   `mapstructure:"tls" json:"tls,omitempty"`               // 用于前端判断生成的安装命令是否启用 TLS
 	Location       string `mapstructure:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
 	ForceAuth      bool   `mapstructure:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
 
@@ -70,6 +70,11 @@ type Config struct {
 	Oauth2 map[string]*Oauth2Config `mapstructure:"oauth2" json:"oauth2,omitempty"`
 	// oauth2 供应商列表，无需配置，自动生成
 	Oauth2Providers []string `yaml:"-" json:"oauth2_providers,omitempty"`
+
+	// TLS 证书配置
+	EnableTLS   bool   `mapstructure:"enable_tls" json:"enable_tls,omitempty"`
+	TLSCertPath string `mapstructure:"tls_cert_path" json:"tls_cert_path,omitempty"`
+	TLSKeyPath  string `mapstructure:"tls_key_path" json:"tls_key_path,omitempty"`
 
 	k        *koanf.Koanf `json:"-"`
 	filePath string       `json:"-"`

--- a/model/config.go
+++ b/model/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-viper/mapstructure/v2"
+	kyaml "github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
@@ -89,7 +90,7 @@ func (c *Config) Read(path string, frontendTemplates []FrontendTemplate) error {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		err = c.k.Load(file.Provider(path), new(utils.KubeYAML))
+		err = c.k.Load(file.Provider(path), kyaml.Parser())
 		if err != nil {
 			return err
 		}
@@ -173,7 +174,7 @@ func (c *Config) updateIgnoredIPNotificationID() {
 // Save 保存配置文件
 func (c *Config) Save() error {
 	c.updateIgnoredIPNotificationID()
-	data, err := c.k.Marshal(new(utils.KubeYAML))
+	data, err := c.k.Marshal(kyaml.Parser())
 	if err != nil {
 		return err
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -1,18 +1,16 @@
 package model
 
 import (
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
-	kyaml "github.com/knadh/koanf/parsers/yaml"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/nezhahq/nezha/pkg/utils"
 )
@@ -35,46 +33,46 @@ type ConfigForGuests struct {
 }
 
 type Config struct {
-	Debug        bool   `mapstructure:"debug" json:"debug,omitempty"`                   // debug模式开关
-	RealIPHeader string `mapstructure:"real_ip_header" json:"real_ip_header,omitempty"` // 真实IP
+	Debug        bool   `koanf:"debug" json:"debug,omitempty"`                   // debug模式开关
+	RealIPHeader string `koanf:"real_ip_header" json:"real_ip_header,omitempty"` // 真实IP
 
-	Language       string `mapstructure:"language" json:"language"` // 系统语言，默认 zh_CN
-	SiteName       string `mapstructure:"site_name" json:"site_name"`
-	UserTemplate   string `mapstructure:"user_template" json:"user_template,omitempty"`
-	AdminTemplate  string `mapstructure:"admin_template" json:"admin_template,omitempty"`
-	JWTSecretKey   string `mapstructure:"jwt_secret_key" json:"jwt_secret_key,omitempty"`
-	AgentSecretKey string `mapstructure:"agent_secret_key" json:"agent_secret_key,omitempty"`
-	ListenPort     uint   `mapstructure:"listen_port" json:"listen_port,omitempty"`
-	ListenHost     string `mapstructure:"listen_host" json:"listen_host,omitempty"`
-	InstallHost    string `mapstructure:"install_host" json:"install_host,omitempty"`
-	AgentTLS       bool   `mapstructure:"tls" json:"tls,omitempty"`               // 用于前端判断生成的安装命令是否启用 TLS
-	Location       string `mapstructure:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
-	ForceAuth      bool   `mapstructure:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
+	Language       string `koanf:"language" json:"language"` // 系统语言，默认 zh_CN
+	SiteName       string `koanf:"site_name" json:"site_name"`
+	UserTemplate   string `koanf:"user_template" json:"user_template,omitempty"`
+	AdminTemplate  string `koanf:"admin_template" json:"admin_template,omitempty"`
+	JWTSecretKey   string `koanf:"jwt_secret_key" json:"jwt_secret_key,omitempty"`
+	AgentSecretKey string `koanf:"agent_secret_key" json:"agent_secret_key,omitempty"`
+	ListenPort     uint   `koanf:"listen_port" json:"listen_port,omitempty"`
+	ListenHost     string `koanf:"listen_host" json:"listen_host,omitempty"`
+	InstallHost    string `koanf:"install_host" json:"install_host,omitempty"`
+	AgentTLS       bool   `koanf:"tls" json:"tls,omitempty"`               // 用于前端判断生成的安装命令是否启用 TLS
+	Location       string `koanf:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
+	ForceAuth      bool   `koanf:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
 
-	EnablePlainIPInNotification bool `mapstructure:"enable_plain_ip_in_notification" json:"enable_plain_ip_in_notification,omitempty"` // 通知信息IP不打码
+	EnablePlainIPInNotification bool `koanf:"enable_plain_ip_in_notification" json:"enable_plain_ip_in_notification,omitempty"` // 通知信息IP不打码
 
 	// IP变更提醒
-	EnableIPChangeNotification  bool   `mapstructure:"enable_ip_change_notification" json:"enable_ip_change_notification,omitempty"`
-	IPChangeNotificationGroupID uint64 `mapstructure:"ip_change_notification_group_id" json:"ip_change_notification_group_id"`
-	Cover                       uint8  `mapstructure:"cover" json:"cover"`                                               // 覆盖范围（0:提醒未被 IgnoredIPNotification 包含的所有服务器; 1:仅提醒被 IgnoredIPNotification 包含的服务器;）
-	IgnoredIPNotification       string `mapstructure:"ignored_ip_notification" json:"ignored_ip_notification,omitempty"` // 特定服务器IP（多个服务器用逗号分隔）
+	EnableIPChangeNotification  bool   `koanf:"enable_ip_change_notification" json:"enable_ip_change_notification,omitempty"`
+	IPChangeNotificationGroupID uint64 `koanf:"ip_change_notification_group_id" json:"ip_change_notification_group_id"`
+	Cover                       uint8  `koanf:"cover" json:"cover"`                                               // 覆盖范围（0:提醒未被 IgnoredIPNotification 包含的所有服务器; 1:仅提醒被 IgnoredIPNotification 包含的服务器;）
+	IgnoredIPNotification       string `koanf:"ignored_ip_notification" json:"ignored_ip_notification,omitempty"` // 特定服务器IP（多个服务器用逗号分隔）
 
-	IgnoredIPNotificationServerIDs map[uint64]bool `mapstructure:"ignored_ip_notification_server_ids" json:"ignored_ip_notification_server_ids,omitempty"` // [ServerID] -> bool(值为true代表当前ServerID在特定服务器列表内）
-	AvgPingCount                   int             `mapstructure:"avg_ping_count" json:"avg_ping_count,omitempty"`
-	DNSServers                     string          `mapstructure:"dns_servers" json:"dns_servers,omitempty"`
+	IgnoredIPNotificationServerIDs map[uint64]bool `koanf:"ignored_ip_notification_server_ids" json:"ignored_ip_notification_server_ids,omitempty"` // [ServerID] -> bool(值为true代表当前ServerID在特定服务器列表内）
+	AvgPingCount                   int             `koanf:"avg_ping_count" json:"avg_ping_count,omitempty"`
+	DNSServers                     string          `koanf:"dns_servers" json:"dns_servers,omitempty"`
 
-	CustomCode          string `mapstructure:"custom_code" json:"custom_code,omitempty"`
-	CustomCodeDashboard string `mapstructure:"custom_code_dashboard" json:"custom_code_dashboard,omitempty"`
+	CustomCode          string `koanf:"custom_code" json:"custom_code,omitempty"`
+	CustomCodeDashboard string `koanf:"custom_code_dashboard" json:"custom_code_dashboard,omitempty"`
 
 	// oauth2 配置
-	Oauth2 map[string]*Oauth2Config `mapstructure:"oauth2" json:"oauth2,omitempty"`
+	Oauth2 map[string]*Oauth2Config `koanf:"oauth2" json:"oauth2,omitempty"`
 	// oauth2 供应商列表，无需配置，自动生成
-	Oauth2Providers []string `yaml:"-" json:"oauth2_providers,omitempty"`
+	Oauth2Providers []string `koanf:"-" json:"oauth2_providers,omitempty"`
 
 	// TLS 证书配置
-	EnableTLS   bool   `mapstructure:"enable_tls" json:"enable_tls,omitempty"`
-	TLSCertPath string `mapstructure:"tls_cert_path" json:"tls_cert_path,omitempty"`
-	TLSKeyPath  string `mapstructure:"tls_key_path" json:"tls_key_path,omitempty"`
+	EnableTLS   bool   `koanf:"enable_tls" json:"enable_tls,omitempty"`
+	TLSCertPath string `koanf:"tls_cert_path" json:"tls_cert_path,omitempty"`
+	TLSKeyPath  string `koanf:"tls_key_path" json:"tls_key_path,omitempty"`
 
 	k        *koanf.Koanf `json:"-"`
 	filePath string       `json:"-"`
@@ -93,16 +91,17 @@ func (c *Config) Read(path string, frontendTemplates []FrontendTemplate) error {
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		err = c.k.Load(file.Provider(path), kyaml.Parser())
+		err = c.k.Load(file.Provider(path), new(utils.KubeYAML))
 		if err != nil {
 			return err
 		}
 	}
 
-	err = c.k.Unmarshal("", c)
+	err = c.k.UnmarshalWithConf("", c, koanfConf(c))
 	if err != nil {
 		return err
 	}
+
 	if c.ListenPort == 0 {
 		c.ListenPort = 8008
 	}
@@ -156,7 +155,7 @@ func (c *Config) Read(path string, frontendTemplates []FrontendTemplate) error {
 		}
 	}
 
-	c.Oauth2Providers = slices.Collect(maps.Keys(c.Oauth2))
+	c.Oauth2Providers = utils.MapKeysToSlice(c.Oauth2)
 
 	c.updateIgnoredIPNotificationID()
 	return nil
@@ -176,7 +175,9 @@ func (c *Config) updateIgnoredIPNotificationID() {
 // Save 保存配置文件
 func (c *Config) Save() error {
 	c.updateIgnoredIPNotificationID()
-	data, err := yaml.Marshal(c)
+	tc := *c
+	tc.Oauth2Providers = nil
+	data, err := yaml.Marshal(&tc)
 	if err != nil {
 		return err
 	}
@@ -187,4 +188,21 @@ func (c *Config) Save() error {
 	}
 
 	return os.WriteFile(c.filePath, data, 0600)
+}
+
+func koanfConf(c any) koanf.UnmarshalConf {
+	return koanf.UnmarshalConf{
+		DecoderConfig: &mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+				utils.TextUnmarshalerHookFunc()),
+			Metadata:         nil,
+			Result:           c,
+			WeaklyTypedInput: true,
+			MatchName: func(mapKey, fieldName string) bool {
+				return strings.EqualFold(mapKey, fieldName) ||
+					strings.EqualFold(mapKey, strings.ReplaceAll(fieldName, "_", ""))
+			},
+		},
+	}
 }

--- a/model/config.go
+++ b/model/config.go
@@ -33,12 +33,13 @@ type ConfigForGuests struct {
 }
 
 type ConfigDashboard struct {
-	Debug         bool   `koanf:"debug" json:"debug,omitempty"`                   // debug模式开关
-	RealIPHeader  string `koanf:"real_ip_header" json:"real_ip_header,omitempty"` // 真实IP
-	UserTemplate  string `koanf:"user_template" json:"user_template,omitempty"`
-	AdminTemplate string `koanf:"admin_template" json:"admin_template,omitempty"`
-	Location      string `koanf:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
-	ForceAuth     bool   `koanf:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
+	Debug          bool   `koanf:"debug" json:"debug,omitempty"`                   // debug模式开关
+	RealIPHeader   string `koanf:"real_ip_header" json:"real_ip_header,omitempty"` // 真实IP
+	UserTemplate   string `koanf:"user_template" json:"user_template,omitempty"`
+	AdminTemplate  string `koanf:"admin_template" json:"admin_template,omitempty"`
+	Location       string `koanf:"location" json:"location,omitempty"`     // 时区，默认为 Asia/Shanghai
+	ForceAuth      bool   `koanf:"force_auth" json:"force_auth,omitempty"` // 强制要求认证
+	AgentSecretKey string `koanf:"agent_secret_key" json:"agent_secret_key,omitempty"`
 
 	EnablePlainIPInNotification bool `koanf:"enable_plain_ip_in_notification" json:"enable_plain_ip_in_notification,omitempty"` // 通知信息IP不打码
 
@@ -57,10 +58,9 @@ type Config struct {
 	ConfigForGuests
 	ConfigDashboard
 
-	JWTSecretKey   string `koanf:"jwt_secret_key" json:"jwt_secret_key,omitempty"`
-	AgentSecretKey string `koanf:"agent_secret_key" json:"agent_secret_key,omitempty"`
-	ListenPort     uint16 `koanf:"listen_port" json:"listen_port,omitempty"`
-	ListenHost     string `koanf:"listen_host" json:"listen_host,omitempty"`
+	JWTSecretKey string `koanf:"jwt_secret_key" json:"jwt_secret_key,omitempty"`
+	ListenPort   uint16 `koanf:"listen_port" json:"listen_port,omitempty"`
+	ListenHost   string `koanf:"listen_host" json:"listen_host,omitempty"`
 
 	// oauth2 配置
 	Oauth2 map[string]*Oauth2Config `koanf:"oauth2" json:"oauth2,omitempty"`

--- a/model/cron.go
+++ b/model/cron.go
@@ -3,7 +3,7 @@ package model
 import (
 	"time"
 
-	"github.com/nezhahq/nezha/pkg/utils"
+	"github.com/goccy/go-json"
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
 )
@@ -34,7 +34,7 @@ type Cron struct {
 }
 
 func (c *Cron) BeforeSave(tx *gorm.DB) error {
-	if data, err := utils.Json.Marshal(c.Servers); err != nil {
+	if data, err := json.Marshal(c.Servers); err != nil {
 		return err
 	} else {
 		c.ServersRaw = string(data)
@@ -43,5 +43,5 @@ func (c *Cron) BeforeSave(tx *gorm.DB) error {
 }
 
 func (c *Cron) AfterFind(tx *gorm.DB) error {
-	return utils.Json.Unmarshal([]byte(c.ServersRaw), &c.Servers)
+	return json.Unmarshal([]byte(c.ServersRaw), &c.Servers)
 }

--- a/model/ddns.go
+++ b/model/ddns.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"github.com/nezhahq/nezha/pkg/utils"
+	"github.com/goccy/go-json"
 	"gorm.io/gorm"
 )
 
@@ -39,7 +39,7 @@ func (d DDNSProfile) TableName() string {
 }
 
 func (d *DDNSProfile) BeforeSave(tx *gorm.DB) error {
-	if data, err := utils.Json.Marshal(d.Domains); err != nil {
+	if data, err := json.Marshal(d.Domains); err != nil {
 		return err
 	} else {
 		d.DomainsRaw = string(data)
@@ -48,5 +48,5 @@ func (d *DDNSProfile) BeforeSave(tx *gorm.DB) error {
 }
 
 func (d *DDNSProfile) AfterFind(tx *gorm.DB) error {
-	return utils.Json.Unmarshal([]byte(d.DomainsRaw), &d.Domains)
+	return json.Unmarshal([]byte(d.DomainsRaw), &d.Domains)
 }

--- a/model/notification.go
+++ b/model/notification.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/nezhahq/nezha/pkg/utils"
 )
 
@@ -66,7 +67,7 @@ func (ns *NotificationServerBundle) reqBody(message string) (string, error) {
 	switch n.RequestType {
 	case NotificationRequestTypeJSON:
 		return ns.replaceParamsInString(n.RequestBody, message, func(msg string) string {
-			msgBytes, _ := utils.Json.Marshal(msg)
+			msgBytes, _ := json.Marshal(msg)
 			return string(msgBytes)[1 : len(msgBytes)-1]
 		}), nil
 	case NotificationRequestTypeForm:

--- a/model/server.go
+++ b/model/server.go
@@ -5,9 +5,9 @@ import (
 	"slices"
 	"time"
 
+	"github.com/goccy/go-json"
 	"gorm.io/gorm"
 
-	"github.com/nezhahq/nezha/pkg/utils"
 	pb "github.com/nezhahq/nezha/proto"
 )
 
@@ -58,13 +58,13 @@ func (s *Server) CopyFromRunningServer(old *Server) {
 
 func (s *Server) AfterFind(tx *gorm.DB) error {
 	if s.DDNSProfilesRaw != "" {
-		if err := utils.Json.Unmarshal([]byte(s.DDNSProfilesRaw), &s.DDNSProfiles); err != nil {
+		if err := json.Unmarshal([]byte(s.DDNSProfilesRaw), &s.DDNSProfiles); err != nil {
 			log.Println("NEZHA>> Server.AfterFind:", err)
 			return nil
 		}
 	}
 	if s.OverrideDDNSDomainsRaw != "" {
-		if err := utils.Json.Unmarshal([]byte(s.OverrideDDNSDomainsRaw), &s.OverrideDDNSDomains); err != nil {
+		if err := json.Unmarshal([]byte(s.OverrideDDNSDomainsRaw), &s.OverrideDDNSDomains); err != nil {
 			log.Println("NEZHA>> Server.AfterFind:", err)
 			return nil
 		}

--- a/model/service.go
+++ b/model/service.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/goccy/go-json"
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
 
-	"github.com/nezhahq/nezha/pkg/utils"
 	pb "github.com/nezhahq/nezha/proto"
 )
 
@@ -91,17 +91,17 @@ func (m *Service) CronSpec() string {
 }
 
 func (m *Service) BeforeSave(tx *gorm.DB) error {
-	if data, err := utils.Json.Marshal(m.SkipServers); err != nil {
+	if data, err := json.Marshal(m.SkipServers); err != nil {
 		return err
 	} else {
 		m.SkipServersRaw = string(data)
 	}
-	if data, err := utils.Json.Marshal(m.FailTriggerTasks); err != nil {
+	if data, err := json.Marshal(m.FailTriggerTasks); err != nil {
 		return err
 	} else {
 		m.FailTriggerTasksRaw = string(data)
 	}
-	if data, err := utils.Json.Marshal(m.RecoverTriggerTasks); err != nil {
+	if data, err := json.Marshal(m.RecoverTriggerTasks); err != nil {
 		return err
 	} else {
 		m.RecoverTriggerTasksRaw = string(data)
@@ -111,16 +111,16 @@ func (m *Service) BeforeSave(tx *gorm.DB) error {
 
 func (m *Service) AfterFind(tx *gorm.DB) error {
 	m.SkipServers = make(map[uint64]bool)
-	if err := utils.Json.Unmarshal([]byte(m.SkipServersRaw), &m.SkipServers); err != nil {
+	if err := json.Unmarshal([]byte(m.SkipServersRaw), &m.SkipServers); err != nil {
 		log.Println("NEZHA>> Service.AfterFind:", err)
 		return nil
 	}
 
 	// 加载触发任务列表
-	if err := utils.Json.Unmarshal([]byte(m.FailTriggerTasksRaw), &m.FailTriggerTasks); err != nil {
+	if err := json.Unmarshal([]byte(m.FailTriggerTasksRaw), &m.FailTriggerTasks); err != nil {
 		return err
 	}
-	if err := utils.Json.Unmarshal([]byte(m.RecoverTriggerTasksRaw), &m.RecoverTriggerTasks); err != nil {
+	if err := json.Unmarshal([]byte(m.RecoverTriggerTasksRaw), &m.RecoverTriggerTasks); err != nil {
 		return err
 	}
 

--- a/model/setting_api.go
+++ b/model/setting_api.go
@@ -18,6 +18,11 @@ type SettingForm struct {
 	EnablePlainIPInNotification bool `json:"enable_plain_ip_in_notification,omitempty" validate:"optional"`
 }
 
+type Setting struct {
+	ConfigForGuests
+	ConfigDashboard
+}
+
 type FrontendTemplate struct {
 	Path       string `json:"path,omitempty"`
 	Name       string `json:"name,omitempty"`
@@ -28,8 +33,8 @@ type FrontendTemplate struct {
 	IsOfficial bool   `json:"is_official,omitempty"`
 }
 
-type SettingResponse[T any] struct {
-	Config T `json:"config,omitempty"`
+type SettingResponse struct {
+	Config Setting `json:"config"`
 
 	Version           string             `json:"version,omitempty"`
 	FrontendTemplates []FrontendTemplate `json:"frontend_templates,omitempty"`

--- a/model/setting_api.go
+++ b/model/setting_api.go
@@ -13,7 +13,7 @@ type SettingForm struct {
 	RealIPHeader                string `json:"real_ip_header,omitempty" validate:"optional"` // 真实IP
 	UserTemplate                string `json:"user_template,omitempty" validate:"optional"`
 
-	TLS                         bool `json:"tls,omitempty" validate:"optional"`
+	AgentTLS                    bool `json:"tls,omitempty" validate:"optional"`
 	EnableIPChangeNotification  bool `json:"enable_ip_change_notification,omitempty" validate:"optional"`
 	EnablePlainIPInNotification bool `json:"enable_plain_ip_in_notification,omitempty" validate:"optional"`
 }

--- a/model/waf.go
+++ b/model/waf.go
@@ -117,7 +117,7 @@ func BlockIP(db *gorm.DB, ip string, reason uint8, uid int64) error {
 	}
 	now := uint64(time.Now().Unix())
 
-	var count interface{}
+	var count any
 	if reason == WAFBlockReasonTypeManual {
 		count = 99999
 	} else {

--- a/pkg/utils/gjson.go
+++ b/pkg/utils/gjson.go
@@ -33,9 +33,7 @@ func GjsonIter(json string) (iter.Seq2[string, string], error) {
 		return nil, ErrGjsonWrongType
 	}
 
-	return func(yield func(string, string) bool) {
-		result.ForEach(func(k, v gjson.Result) bool {
-			return yield(k.String(), v.String())
-		})
-	}, nil
+	return ConvertSeq2(result.ForEach, func(k, v gjson.Result) (string, string) {
+		return k.String(), v.String()
+	}), nil
 }

--- a/pkg/utils/koanf.go
+++ b/pkg/utils/koanf.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"encoding"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
+	"sigs.k8s.io/yaml"
+)
+
+// TextUnmarshalerHookFunc is a fixed version of mapstructure.TextUnmarshallerHookFunc.
+// This hook allows to additionally unmarshal text into custom string types that implement the encoding.Text(Un)Marshaler interface(s).
+func TextUnmarshalerHookFunc() mapstructure.DecodeHookFuncType {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		result := reflect.New(t).Interface()
+		unmarshaller, ok := result.(encoding.TextUnmarshaler)
+		if !ok {
+			return data, nil
+		}
+
+		// default text representation is the actual value of the `from` string
+		var (
+			dataVal = reflect.ValueOf(data)
+			text    = []byte(dataVal.String())
+		)
+		if f.Kind() == t.Kind() {
+			// source and target are of underlying type string
+			var (
+				err    error
+				ptrVal = reflect.New(dataVal.Type())
+			)
+			if !ptrVal.Elem().CanSet() {
+				// cannot set, skip, this should not happen
+				if err := unmarshaller.UnmarshalText(text); err != nil {
+					return nil, err
+				}
+				return result, nil
+			}
+			ptrVal.Elem().Set(dataVal)
+
+			// We need to assert that both, the value type and the pointer type
+			// do (not) implement the TextMarshaller interface before proceeding and simply
+			// using the string value of the string type.
+			// it might be the case that the internal string representation differs from
+			// the (un)marshalled string.
+
+			for _, v := range []reflect.Value{dataVal, ptrVal} {
+				if marshaller, ok := v.Interface().(encoding.TextMarshaler); ok {
+					text, err = marshaller.MarshalText()
+					if err != nil {
+						return nil, err
+					}
+					break
+				}
+			}
+		}
+
+		// text is either the source string's value or the source string type's marshaled value
+		// which may differ from its internal string value.
+		if err := unmarshaller.UnmarshalText(text); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+}
+
+type KubeYAML struct{}
+
+// Unmarshal parses the given YAML bytes.
+func (k *KubeYAML) Unmarshal(b []byte) (map[string]any, error) {
+	var out map[string]any
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// Marshal marshals the given config map to YAML bytes.
+func (k *KubeYAML) Marshal(o map[string]any) ([]byte, error) {
+	return yaml.Marshal(o)
+}

--- a/pkg/utils/koanf.go
+++ b/pkg/utils/koanf.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/go-viper/mapstructure/v2"
-	"sigs.k8s.io/yaml"
 )
 
 // TextUnmarshalerHookFunc is a fixed version of mapstructure.TextUnmarshallerHookFunc.
@@ -69,21 +68,4 @@ func TextUnmarshalerHookFunc() mapstructure.DecodeHookFuncType {
 		}
 		return result, nil
 	}
-}
-
-type KubeYAML struct{}
-
-// Unmarshal parses the given YAML bytes.
-func (k *KubeYAML) Unmarshal(b []byte) (map[string]any, error) {
-	var out map[string]any
-	if err := yaml.Unmarshal(b, &out); err != nil {
-		return nil, err
-	}
-
-	return out, nil
-}
-
-// Marshal marshals the given config map to YAML bytes.
-func (k *KubeYAML) Marshal(o map[string]any) ([]byte, error) {
-	return yaml.Marshal(o)
 }

--- a/pkg/utils/koanf.go
+++ b/pkg/utils/koanf.go
@@ -14,8 +14,8 @@ func TextUnmarshalerHookFunc() mapstructure.DecodeHookFuncType {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{},
-	) (interface{}, error) {
+		data any,
+	) (any, error) {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -71,7 +71,7 @@ func GenerateRandomString(n int) (string, error) {
 	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	lettersLength := big.NewInt(int64(len(letters)))
 	ret := make([]byte, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		num, err := rand.Int(rand.Reader, lettersLength)
 		if err != nil {
 			return "", err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"cmp"
 	"crypto/rand"
 	"errors"
 	"iter"
@@ -114,16 +115,19 @@ func MapValuesToSlice[Map ~map[K]V, K comparable, V any](m Map) []V {
 	return slices.AppendSeq(s, maps.Values(m))
 }
 
-func Unique[T comparable](s []T) []T {
-	m := make(map[T]struct{})
-	ret := make([]T, 0, len(s))
-	for _, v := range s {
-		if _, ok := m[v]; !ok {
-			m[v] = struct{}{}
-			ret = append(ret, v)
-		}
+func MapKeysToSlice[Map ~map[K]V, K comparable, V any](m Map) []K {
+	s := make([]K, 0, len(m))
+	return slices.AppendSeq(s, maps.Keys(m))
+}
+
+func Unique[S ~[]E, E cmp.Ordered](list S) S {
+	if list == nil {
+		return nil
 	}
-	return ret
+	out := make([]E, len(list))
+	copy(out, list)
+	slices.Sort(out)
+	return slices.Compact(out)
 }
 
 func ConvertSeq[In, Out any](seq iter.Seq[In], f func(In) Out) iter.Seq[Out] {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -43,7 +43,7 @@ func TestNotification(t *testing.T) {
 
 func TestGenerGenerateRandomString(t *testing.T) {
 	generatedString := make(map[string]bool)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		str, err := GenerateRandomString(32)
 		if err != nil {
 			t.Fatalf("Error: %s", err)

--- a/service/singleton/alertsentinel.go
+++ b/service/singleton/alertsentinel.go
@@ -96,7 +96,7 @@ func OnRefreshOrAddAlert(alert *model.AlertRule) {
 	delete(alertsStore, alert.ID)
 	delete(alertsPrevState, alert.ID)
 	var isEdit bool
-	for i := 0; i < len(Alerts); i++ {
+	for i := range Alerts {
 		if Alerts[i].ID == alert.ID {
 			Alerts[i] = alert
 			isEdit = true

--- a/service/singleton/user.go
+++ b/service/singleton/user.go
@@ -52,7 +52,7 @@ func OnUserUpdate(u *model.User) {
 	AgentSecretToUserId[u.AgentSecret] = u.ID
 }
 
-func OnUserDelete(id []uint64, errorFunc func(string, ...interface{}) error) error {
+func OnUserDelete(id []uint64, errorFunc func(string, ...any) error) error {
 	UserLock.Lock()
 	defer UserLock.Unlock()
 


### PR DESCRIPTION
- `http.Server` 已经支持 HTTP/2 PRI, 不再需要使用 h2c 库
- 将 `jsoniter` 替换为目前仍在维护的 `goccy/go-json`
- 支持 HTTPS，可以用于一些特殊场景（比如 Cloudflare Tunnel 需要 HTTPS 才能处理 h2）
- 配置字段支持下划线格式
- 翻新一些语法