### PR TITLE
generate agent_secret for old users

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -13,6 +13,8 @@ const (
 	RoleMember
 )
 
+const DefaultAgentSecretLength = 32
+
 type User struct {
 	Common
 	Username       string `json:"username,omitempty" gorm:"uniqueIndex"`
@@ -32,7 +34,7 @@ func (u *User) BeforeSave(tx *gorm.DB) error {
 		return nil
 	}
 
-	key, err := utils.GenerateRandomString(32)
+	key, err := utils.GenerateRandomString(DefaultAgentSecretLength)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"iter"
 	"maps"
 	"math/big"
@@ -80,6 +81,14 @@ func GenerateRandomString(n int) (string, error) {
 		ret[i] = letters[num.Int64()]
 	}
 	return string(ret), nil
+}
+
+func MustGenerateRandomString(n int) string {
+	str, err := GenerateRandomString(n)
+	if err != nil {
+		panic(fmt.Errorf("MustGenerateRandomString: %v", err))
+	}
+	return str
 }
 
 func Uint64SubInt64(a uint64, b int64) uint64 {

--- a/service/singleton/user.go
+++ b/service/singleton/user.go
@@ -1,9 +1,11 @@
 package singleton
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/nezhahq/nezha/model"
+	"github.com/nezhahq/nezha/pkg/utils"
 	"gorm.io/gorm"
 )
 
@@ -29,6 +31,13 @@ func initUser() {
 	AgentSecretToUserId[Conf.AgentSecretKey] = 0
 
 	for _, u := range users {
+		if u.AgentSecret == "" {
+			u.AgentSecret = utils.MustGenerateRandomString(model.DefaultAgentSecretLength)
+			if err := DB.Save(&u).Error; err != nil {
+				panic(fmt.Errorf("update of user %d failed: %v", u.ID, err))
+			}
+		}
+
 		UserInfoMap[u.ID] = model.UserInfo{
 			Role:        u.Role,
 			AgentSecret: u.AgentSecret,


### PR DESCRIPTION
Since the `agent_secret` field in configuration is not exposed anymore and should be deprecated, now generates a key for users that who lacks `agent_secret` in their profile (usually seen in older installations)