### PR TITLE
bugfix: 数据回收任务创建失败

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -66,12 +66,12 @@ func initSystem(bus chan<- *model.Service) error {
 	}
 
 	// 每天的3:30 对 监控记录 和 流量记录 进行清理
-	if _, err := singleton.CronShared.AddFunc("0 30 3 * * *", singleton.CleanServiceHistory); err != nil {
+	if _, err := singleton.CronShared.AddFunc("30 3 * * *", singleton.CleanServiceHistory); err != nil {
 		return err
 	}
 
 	// 每小时对流量记录进行打点
-	if _, err := singleton.CronShared.AddFunc("0 0 * * * *", func() { singleton.RecordTransferHourlyUsage() }); err != nil {
+	if _, err := singleton.CronShared.AddFunc("0 * * * *", func() { singleton.RecordTransferHourlyUsage() }); err != nil {
 		return err
 	}
 	return nil

--- a/service/singleton/servicesentinel.go
+++ b/service/singleton/servicesentinel.go
@@ -130,7 +130,7 @@ func NewServiceSentinel(serviceSentinelDispatchBus chan<- *model.Service) (*Serv
 	go ss.worker()
 
 	// 每日将游标往后推一天
-	_, err = CronShared.AddFunc("0 0 0 * * *", ss.refreshMonthlyServiceStatus)
+	_, err = CronShared.AddFunc("0 0 * * *", ss.refreshMonthlyServiceStatus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
我自己打了个服务端发现定时清理数据的任务没有生效，6月份的数据还在
<img width="1151" height="184" alt="image" src="https://github.com/user-attachments/assets/b1dd773d-8cc0-4644-b0d3-5f7bd876db9d" />

我看底层依赖的cron包第一个参数是五个元素（分、时、日、月、周）
https://github.com/robfig/cron/blob/bc59245fe10efaed9d51b56900192527ed733435/doc.go#L22
<img width="1388" height="940" alt="image" src="https://github.com/user-attachments/assets/f2687a0c-351c-4690-add3-ec3325c0690d" />
