### PR TITLE
fix: 修复空周期流量规则列表导致流量历史清理失效

### DIFF
--- a/service/singleton/clean_monitor_history_test.go
+++ b/service/singleton/clean_monitor_history_test.go
@@ -14,11 +14,18 @@ func setupCleanMonitorHistoryTestDB(t *testing.T) {
 	t.Helper()
 
 	previousDB := DB
-	t.Cleanup(func() { DB = previousDB })
-
 	var err error
 	DB, err = gorm.Open(openSQLiteDialector(filepath.Join(t.TempDir(), "dashboard.sqlite")), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, err := DB.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		DB = previousDB
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close transfer cleanup test database: %v", err)
+		}
+	})
+
 	require.NoError(t, DB.AutoMigrate(&model.Server{}, &model.Transfer{}, &model.AlertRule{}))
 	require.NoError(t, DB.Exec("INSERT INTO servers (id, name, uuid) VALUES (1, 'server', 'clean-monitor-history-test')").Error)
 }

--- a/service/singleton/clean_monitor_history_test.go
+++ b/service/singleton/clean_monitor_history_test.go
@@ -1,0 +1,50 @@
+package singleton
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/nezhahq/nezha/model"
+)
+
+func setupCleanMonitorHistoryTestDB(t *testing.T) {
+	t.Helper()
+
+	previousDB := DB
+	t.Cleanup(func() { DB = previousDB })
+
+	var err error
+	DB, err = gorm.Open(openSQLiteDialector(filepath.Join(t.TempDir(), "dashboard.sqlite")), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, DB.AutoMigrate(&model.Server{}, &model.Transfer{}, &model.AlertRule{}))
+	require.NoError(t, DB.Exec("INSERT INTO servers (id, name, uuid) VALUES (1, 'server', 'clean-monitor-history-test')").Error)
+}
+
+func TestCleanMonitorHistoryWithoutRulesDeletesAllTransfers(t *testing.T) {
+	setupCleanMonitorHistoryTestDB(t)
+	require.NoError(t, DB.Create(&model.Transfer{ServerID: 1, In: 1}).Error)
+
+	CleanMonitorHistory()
+
+	var count int64
+	require.NoError(t, DB.Model(&model.Transfer{}).Count(&count).Error)
+	require.Zero(t, count)
+}
+
+func TestCleanMonitorHistoryPreservesTransfersWhenAlertRulesCannotBeLoaded(t *testing.T) {
+	setupCleanMonitorHistoryTestDB(t)
+	require.NoError(t, DB.Create(&model.Transfer{ServerID: 1, In: 1}).Error)
+	require.NoError(t, DB.Exec("INSERT INTO alert_rules (id, name, rules_raw, fail_trigger_tasks_raw, recover_trigger_tasks_raw) VALUES (1, 'broken', '{', '[]', '[]')").Error)
+
+	var alerts []model.AlertRule
+	require.Error(t, DB.Find(&alerts).Error, "precondition: malformed rules_raw must fail AlertRule.AfterFind")
+
+	CleanMonitorHistory()
+
+	var count int64
+	require.NoError(t, DB.Model(&model.Transfer{}).Count(&count).Error)
+	require.EqualValues(t, 1, count)
+}

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -188,6 +188,14 @@ func CleanMonitorHistory() {
 	for id, couldRemove := range specialServerKeep {
 		DB.Unscoped().Delete(&model.Transfer{}, "server_id = ? AND datetime(`created_at`) < datetime(?)", id, couldRemove)
 	}
+	if len(specialServerIDs) == 0 {
+		if allServerKeep.IsZero() {
+			DB.Unscoped().Where("1 = 1").Delete(&model.Transfer{})
+		} else {
+			DB.Unscoped().Delete(&model.Transfer{}, "datetime(`created_at`) < datetime(?)", allServerKeep)
+		}
+		return
+	}
 	if allServerKeep.IsZero() {
 		DB.Unscoped().Delete(&model.Transfer{}, "server_id NOT IN (?)", specialServerIDs)
 	} else {

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -160,7 +160,10 @@ func CleanMonitorHistory() {
 	specialServerKeep := make(map[uint64]time.Time)
 	var specialServerIDs []uint64
 	var alerts []model.AlertRule
-	DB.Find(&alerts)
+	if err := DB.Find(&alerts).Error; err != nil {
+		log.Printf("NEZHA>> Failed to load alert rules while cleaning transfer history: %v", err)
+		return
+	}
 	for _, alert := range alerts {
 		for _, rule := range alert.Rules {
 			// 是不是流量记录规则
@@ -190,7 +193,7 @@ func CleanMonitorHistory() {
 	}
 	if len(specialServerIDs) == 0 {
 		if allServerKeep.IsZero() {
-			DB.Unscoped().Where("1 = 1").Delete(&model.Transfer{})
+			DB.Unscoped().Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&model.Transfer{})
 		} else {
 			DB.Unscoped().Delete(&model.Transfer{}, "datetime(`created_at`) < datetime(?)", allServerKeep)
 		}


### PR DESCRIPTION
## 问题
当 `specialServerIDs` 为空时，GORM 会将 `NOT IN (?)` 展开为等价于 `NOT IN (NULL)` 的表达式。
SQLite 在这种情况下不会匹配任何记录，导致流量历史清理静默失效，`transfers` 表持续增长。

## 修复
单独处理 `specialServerIDs` 为空的情况：
- 没有周期流量规则需要保留数据时，删除全部流量历史，避免无界增长；
- 存在全局周期流量规则时，直接按 `created_at` 清理；
- `specialServerIDs` 非空时保持原有逻辑不变。
