### PR TITLE
feat.主题强兼（强行兼容）komari

### DIFF
--- a/cmd/dashboard/controller/controller.go
+++ b/cmd/dashboard/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -356,8 +357,22 @@ func getUid(c *gin.Context) uint64 {
 	return user.ID
 }
 
+func resolveUserFrontendTemplate(selected string) (templateRoot, wallpaper string) {
+	if root, marketWallpaper, ok := singleton.ResolveKomariFrontendTemplate(selected); ok {
+		return root, marketWallpaper
+	}
+	return selected, ""
+}
+
+func prepareFrontendIndex(document []byte, wallpaper, selectedTemplate string) []byte {
+	if wallpaper == "" {
+		return document
+	}
+	return singleton.InjectKomariCompatibility(document, selectedTemplate, wallpaper)
+}
+
 func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
-	serveFile := func(c *gin.Context, name string, file fs.File, customStatusCode int) bool {
+	serveFile := func(c *gin.Context, name string, file fs.File, customStatusCode int, wallpaper, selectedTemplate string) bool {
 		defer file.Close()
 		fileStat, err := file.Stat()
 		if err != nil {
@@ -370,18 +385,70 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 		if !ok {
 			return false
 		}
+		if name == "index.html" && wallpaper != "" {
+			document, readErr := io.ReadAll(io.LimitReader(readSeeker, 2<<20))
+			if readErr != nil {
+				return false
+			}
+			document = prepareFrontendIndex(document, wallpaper, selectedTemplate)
+			c.Data(customStatusCode, "text/html; charset=utf-8", document)
+			return true
+		}
 		http.ServeContent(utils.NewGinCustomWriter(c, customStatusCode), c.Request, name, fileStat.ModTime(), readSeeker)
 		return true
 	}
 
-	checkLocalFileOrFs := func(c *gin.Context, frontendFS fs.FS, templateRoot, filePath string, customStatusCode int) bool {
+	checkLocalFileOrFs := func(c *gin.Context, frontendFS fs.FS, templateRoot, filePath string, customStatusCode int, wallpaper, selectedTemplate string) bool {
 		if filePath != "" {
 			localRoot, err := os.OpenRoot(templateRoot)
 			if err == nil {
 				defer localRoot.Close()
 				// URL paths must stay inside the selected template root; never join them against the process cwd.
-				if file, err := localRoot.Open(filePath); err == nil && serveFile(c, filePath, file, customStatusCode) {
+				if file, err := localRoot.Open(filePath); err == nil && serveFile(c, filePath, file, customStatusCode, wallpaper, selectedTemplate) {
 					return true
+				}
+				// Some Komari themes emit lower-case asset URLs while their ZIP stores
+				// upper-case country codes. Resolve each segment case-insensitively,
+				// without modifying the third-party package or escaping its root.
+				parts := strings.Split(filePath, "/")
+				resolved := make([]string, 0, len(parts))
+				current := "."
+				valid := true
+				for _, part := range parts {
+					if part == "" || part == "." || part == ".." {
+						valid = false
+						break
+					}
+					dir, openDirErr := localRoot.Open(current)
+					if openDirErr != nil {
+						valid = false
+						break
+					}
+					entries, readErr := dir.ReadDir(-1)
+					dir.Close()
+					if readErr != nil {
+						valid = false
+						break
+					}
+					match := ""
+					for _, entry := range entries {
+						if strings.EqualFold(entry.Name(), part) {
+							match = entry.Name()
+							break
+						}
+					}
+					if match == "" {
+						valid = false
+						break
+					}
+					resolved = append(resolved, match)
+					current = strings.Join(resolved, "/")
+				}
+				if valid {
+					resolvedPath := strings.Join(resolved, "/")
+					if file, openErr := localRoot.Open(resolvedPath); openErr == nil && serveFile(c, resolvedPath, file, customStatusCode, wallpaper, selectedTemplate) {
+						return true
+					}
 				}
 			}
 		}
@@ -397,7 +464,7 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 		if err != nil {
 			return false
 		}
-		if serveFile(c, filePath, file, customStatusCode) {
+		if serveFile(c, filePath, file, customStatusCode, wallpaper, selectedTemplate) {
 			return true
 		}
 		return false
@@ -441,9 +508,40 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 	}
 
 	return func(c *gin.Context) {
+		// Komari themes use /admin or /login for their own control panel. This
+		// deployment keeps Nezha's original admin/login frontend authoritative.
+		if strings.HasPrefix(singleton.Conf.UserTemplate, "komari-market-") {
+			switch strings.TrimRight(c.Request.URL.Path, "/") {
+			case "/admin", "/admin/login", "/login":
+				c.Redirect(http.StatusTemporaryRedirect, "/dashboard")
+				return
+			}
+		}
 		if strings.HasPrefix(c.Request.URL.Path, "/api") {
 			c.JSON(http.StatusNotFound, newErrorResponse(errors.New("404 Not Found")))
 			return
+		}
+
+		// Komari mounts theme metadata/assets below /themes/{short}/. Keep a
+		// compatibility alias to the verified local package, without editing it.
+		if strings.HasPrefix(singleton.Conf.UserTemplate, "komari-market-") {
+			short := strings.TrimPrefix(singleton.Conf.UserTemplate, "komari-market-")
+			prefix := "/themes/" + short + "/"
+			if strings.HasPrefix(c.Request.URL.Path, prefix) {
+				templateRoot, wallpaper := resolveUserFrontendTemplate(singleton.Conf.UserTemplate)
+				rel := strings.TrimPrefix(c.Request.URL.Path, prefix)
+				if rel == "komari-theme.json" {
+					if checkLocalFileOrFs(c, frontendDist, filepath.Dir(templateRoot), rel, http.StatusOK, "", singleton.Conf.UserTemplate) {
+						return
+					}
+				}
+				if strings.HasPrefix(rel, "dist/") {
+					rel = strings.TrimPrefix(rel, "dist/")
+					if checkLocalFileOrFs(c, frontendDist, templateRoot, rel, http.StatusOK, wallpaper, singleton.Conf.UserTemplate) {
+						return
+					}
+				}
+			}
 		}
 
 		// redirect for /dashboard to /dashboard/
@@ -456,19 +554,40 @@ func fallbackToFrontend(frontendDist fs.FS) func(*gin.Context) {
 		// Only /dashboard/ belongs to the admin frontend; /dashboard.. must not be trimmed into ../.
 		if strings.HasPrefix(c.Request.URL.Path, "/dashboard/") {
 			stripPath := strings.TrimPrefix(c.Request.URL.Path, "/dashboard/")
-			if checkLocalFileOrFs(c, frontendDist, singleton.Conf.AdminTemplate, stripPath, http.StatusOK) {
+			if checkLocalFileOrFs(c, frontendDist, singleton.Conf.AdminTemplate, stripPath, http.StatusOK, "", singleton.Conf.AdminTemplate) {
 				return
 			}
-			if !checkLocalFileOrFs(c, frontendDist, singleton.Conf.AdminTemplate, "index.html", fallbackStatusCode) {
+			if !checkLocalFileOrFs(c, frontendDist, singleton.Conf.AdminTemplate, "index.html", fallbackStatusCode, "", singleton.Conf.AdminTemplate) {
 				c.JSON(http.StatusNotFound, newErrorResponse(errors.New("404 Not Found")))
 			}
 			return
 		}
 		stripPath := strings.TrimPrefix(c.Request.URL.Path, "/")
-		if checkLocalFileOrFs(c, frontendDist, singleton.Conf.UserTemplate, stripPath, http.StatusOK) {
+		templateRoot, wallpaper := resolveUserFrontendTemplate(singleton.Conf.UserTemplate)
+		if checkLocalFileOrFs(c, frontendDist, templateRoot, stripPath, http.StatusOK, wallpaper, singleton.Conf.UserTemplate) {
 			return
 		}
-		if !checkLocalFileOrFs(c, frontendDist, singleton.Conf.UserTemplate, "index.html", fallbackStatusCode) {
+		// Some theme ZIPs reference Komari backend-owned shared flags/OS logos
+		// that are bundled only by another verified theme package.
+		if strings.HasPrefix(singleton.Conf.UserTemplate, "komari-market-") &&
+			(strings.HasPrefix(stripPath, "assets/flags/") || strings.HasPrefix(stripPath, "assets/logo/") ||
+				strings.HasPrefix(stripPath, "images/flags/") || strings.HasPrefix(stripPath, "images/logo/")) {
+			assetTail := strings.TrimPrefix(strings.TrimPrefix(stripPath, "assets/"), "images/")
+			if entries, readErr := os.ReadDir(singleton.KomariThemeInstallDir()); readErr == nil {
+				for _, entry := range entries {
+					if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "komari-market-") {
+						continue
+					}
+					for _, prefix := range []string{"assets", "images"} {
+						candidateRoot := filepath.Join(singleton.KomariThemeInstallDir(), entry.Name(), "dist", prefix)
+						if checkLocalFileOrFs(c, frontendDist, candidateRoot, assetTail, http.StatusOK, "", singleton.Conf.UserTemplate) {
+							return
+						}
+					}
+				}
+			}
+		}
+		if !checkLocalFileOrFs(c, frontendDist, templateRoot, "index.html", fallbackStatusCode, wallpaper, singleton.Conf.UserTemplate) {
 			c.JSON(http.StatusNotFound, newErrorResponse(errors.New("404 Not Found")))
 		}
 	}

--- a/cmd/dashboard/controller/komari_admin_redirect_test.go
+++ b/cmd/dashboard/controller/komari_admin_redirect_test.go
@@ -1,0 +1,52 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nezhahq/nezha/model"
+	"github.com/nezhahq/nezha/service/singleton"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKomariAdminPathsRedirectToNezhaDashboard(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{
+		AdminTemplate: "admin-dist", UserTemplate: "komari-market-kumo",
+	}}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-kumo": "https://example.com/p.png"}
+	t.Cleanup(func() { singleton.Conf = original; singleton.KomariThemeWallpapers = nil })
+
+	dist := fstest.MapFS{
+		"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin index")},
+		"user-dist/index.html":  &fstest.MapFile{Data: []byte("user index")},
+	}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(dist))
+
+	for _, path := range []string{"/admin", "/admin/", "/admin/login", "/login"} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusTemporaryRedirect, rec.Code, path)
+		require.Equal(t, "/dashboard", rec.Header().Get("Location"), path)
+	}
+}
+
+func TestOfficialThemeDoesNotHijackUnrelatedLoginPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{
+		AdminTemplate: "admin-dist", UserTemplate: "user-dist",
+	}}}
+	t.Cleanup(func() { singleton.Conf = original })
+	dist := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("user")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(dist))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/login", nil))
+	require.NotEqual(t, http.StatusTemporaryRedirect, rec.Code)
+}

--- a/cmd/dashboard/controller/komari_case_insensitive_asset_test.go
+++ b/cmd/dashboard/controller/komari_case_insensitive_asset_test.go
@@ -1,0 +1,67 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nezhahq/nezha/model"
+	"github.com/nezhahq/nezha/service/singleton"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKomariThemeAssetsResolveCaseInsensitivePathSegments(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	distRoot := filepath.Join(root, "komari-market-material", "dist")
+	require.NoError(t, os.MkdirAll(filepath.Join(distRoot, "images", "flags"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(distRoot, "index.html"), []byte("material"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(distRoot, "images", "flags", "CA.svg"), []byte("canada"), 0o644))
+
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-material"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-material": {Short: "material", Preview: "https://example.com/p.png"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-material": "https://example.com/p.png"}
+	t.Cleanup(func() {
+		singleton.Conf = original
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+
+	embed := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("official")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(embed))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/images/flags/ca.svg", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "canada", rec.Body.String())
+}
+
+func TestKomariThemeMissingAssetStillReturnsNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	distRoot := filepath.Join(root, "komari-market-material", "dist")
+	require.NoError(t, os.MkdirAll(distRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(distRoot, "index.html"), []byte("material"), 0o644))
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-material"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-material": {Short: "material", Preview: "https://example.com/p.png"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-material": "https://example.com/p.png"}
+	t.Cleanup(func() {
+		singleton.Conf = original
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+	embed := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("official")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(embed))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/images/flags/no-such.svg", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/cmd/dashboard/controller/komari_frontend_test.go
+++ b/cmd/dashboard/controller/komari_frontend_test.go
@@ -1,0 +1,137 @@
+package controller
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nezhahq/nezha/model"
+	"github.com/nezhahq/nezha/service/singleton"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveFrontendTemplateMapsDynamicKomariEntryToOfficialDist(t *testing.T) {
+	singleton.KomariThemeWallpapers = map[string]string{
+		"komari-market-future": "https://cdn.example/future.webp",
+	}
+	t.Cleanup(func() { singleton.KomariThemeWallpapers = nil })
+
+	root, wallpaper := resolveUserFrontendTemplate("komari-market-future")
+	require.Equal(t, "user-dist", root)
+	require.Equal(t, "https://cdn.example/future.webp", wallpaper)
+
+	root, wallpaper = resolveUserFrontendTemplate("nazhua-dist")
+	require.Equal(t, "nazhua-dist", root)
+	require.Empty(t, wallpaper)
+}
+
+func TestPrepareFrontendIndexInjectsDynamicKomariWallpaper(t *testing.T) {
+	raw := []byte(`<html><head></head><body></body></html>`)
+	out := string(prepareFrontendIndex(raw, "https://cdn.example/future.webp", "komari-market-future"))
+	require.Contains(t, out, "CustomBackgroundImage")
+	require.Contains(t, out, "https://cdn.example/future.webp")
+	require.Contains(t, out, "komari-market-future")
+}
+
+func TestFallbackServesKomariManifestCompatibilityPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	themeRoot := filepath.Join(root, "komari-market-future")
+	require.NoError(t, os.MkdirAll(filepath.Join(themeRoot, "dist"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(themeRoot, "dist", "index.html"), []byte("theme"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(themeRoot, "komari-theme.json"), []byte(`{"short":"future","configuration":{"backgroundImage":{"default":"x"}}}`), 0o644))
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-future"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-future": {Short: "future", Preview: "https://example.com/p.png"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-future": "https://example.com/p.png"}
+	t.Cleanup(func() {
+		singleton.Conf = original
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+	embed := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("official")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(embed))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/themes/future/komari-theme.json", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, `{"short":"future","configuration":{"backgroundImage":{"default":"x"}}}`, rec.Body.String())
+	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+}
+
+func TestFallbackServesInstalledKomariThemeAssetsInsteadOfOfficialAssets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	themeDist := filepath.Join(root, "komari-market-future", "dist")
+	require.NoError(t, os.MkdirAll(filepath.Join(themeDist, "assets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(themeDist, "index.html"), []byte(`<html><head><script src="/assets/komari.js"></script></head><body id="real-komari"></body></html>`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(themeDist, "assets", "komari.js"), []byte(`window.realKomariTheme=true`), 0o644))
+
+	originalConf := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-future"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-future": {Short: "future", Preview: "https://cdn.example/future.webp"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-future": "https://cdn.example/future.webp"}
+	t.Cleanup(func() {
+		singleton.Conf = originalConf
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+
+	dist := fstest.MapFS{"user-dist/index.html": &fstest.MapFile{Data: []byte(`<html><body id="official"></body></html>`)}, "admin-dist/index.html": &fstest.MapFile{Data: []byte(`admin`)}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(dist))
+
+	indexRec := httptest.NewRecorder()
+	r.ServeHTTP(indexRec, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusOK, indexRec.Code)
+	require.Contains(t, indexRec.Body.String(), `real-komari`)
+	require.NotContains(t, indexRec.Body.String(), `id="official"`)
+	require.Contains(t, indexRec.Body.String(), `nezha-komari-api-shim`)
+
+	assetRec := httptest.NewRecorder()
+	r.ServeHTTP(assetRec, httptest.NewRequest(http.MethodGet, "/assets/komari.js", nil))
+	require.Equal(t, http.StatusOK, assetRec.Code)
+	require.Equal(t, `window.realKomariTheme=true`, assetRec.Body.String())
+}
+
+func TestFallbackServesOfficialAssetsAndInjectedIndexForDynamicTheme(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	originalConf := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{
+		AdminTemplate: "admin-dist", UserTemplate: "komari-market-future",
+	}}}
+	singleton.KomariThemeWallpapers = map[string]string{
+		"komari-market-future": "https://cdn.example/future.webp",
+	}
+	t.Cleanup(func() {
+		singleton.Conf = originalConf
+		singleton.KomariThemeWallpapers = nil
+	})
+
+	dist := fstest.MapFS{
+		"user-dist/index.html":    &fstest.MapFile{Data: []byte(`<html><head></head><body>official</body></html>`)},
+		"user-dist/assets/app.js": &fstest.MapFile{Data: []byte(`console.log("official")`)},
+		"admin-dist/index.html":   &fstest.MapFile{Data: []byte(`<html><body>admin</body></html>`)},
+	}
+	var frontend fs.FS = dist
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(frontend))
+
+	indexRec := httptest.NewRecorder()
+	r.ServeHTTP(indexRec, httptest.NewRequest(http.MethodGet, "/", nil))
+	require.Equal(t, http.StatusOK, indexRec.Code)
+	require.Contains(t, indexRec.Body.String(), "https://cdn.example/future.webp")
+	require.Contains(t, indexRec.Body.String(), "official")
+
+	assetRec := httptest.NewRecorder()
+	r.ServeHTTP(assetRec, httptest.NewRequest(http.MethodGet, "/assets/app.js", nil))
+	require.Equal(t, http.StatusOK, assetRec.Code)
+	require.Equal(t, `console.log("official")`, assetRec.Body.String())
+}

--- a/cmd/dashboard/controller/komari_shared_asset_test.go
+++ b/cmd/dashboard/controller/komari_shared_asset_test.go
@@ -1,0 +1,69 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/nezhahq/nezha/model"
+	"github.com/nezhahq/nezha/service/singleton"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKomariSharedBackendAssetsCanComeFromAnotherVerifiedTheme(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	selected := filepath.Join(root, "komari-market-emerald", "dist")
+	provider := filepath.Join(root, "komari-market-material", "dist", "images", "logo")
+	require.NoError(t, os.MkdirAll(selected, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(selected, "index.html"), []byte("emerald"), 0o644))
+	require.NoError(t, os.MkdirAll(provider, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(provider, "linux.svg"), []byte("shared-linux"), 0o644))
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-emerald"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-emerald": {Short: "emerald", Preview: "https://example.com/p.png"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-emerald": "https://example.com/p.png"}
+	t.Cleanup(func() {
+		singleton.Conf = original
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+	embed := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("official")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(embed))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/logo/linux.svg", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "shared-linux", rec.Body.String())
+	require.Equal(t, "image/svg+xml", rec.Header().Get("Content-Type"))
+}
+
+func TestKomariSharedBackendAssetLookupCannotEscapeThemeDirectory(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	selected := filepath.Join(root, "komari-market-emerald", "dist")
+	require.NoError(t, os.MkdirAll(selected, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(selected, "index.html"), []byte("emerald"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "secret"), []byte("secret"), 0o600))
+	original := singleton.Conf
+	singleton.Conf = &singleton.ConfigClass{Config: &model.Config{ConfigDashboard: model.ConfigDashboard{AdminTemplate: "admin-dist", UserTemplate: "komari-market-emerald"}}}
+	singleton.KomariThemeCatalog = map[string]singleton.KomariThemeMetadata{"komari-market-emerald": {Short: "emerald", Preview: "https://example.com/p.png"}}
+	singleton.KomariThemeWallpapers = map[string]string{"komari-market-emerald": "https://example.com/p.png"}
+	t.Cleanup(func() {
+		singleton.Conf = original
+		singleton.KomariThemeCatalog = nil
+		singleton.KomariThemeWallpapers = nil
+	})
+	embed := fstest.MapFS{"admin-dist/index.html": &fstest.MapFile{Data: []byte("admin")}, "user-dist/index.html": &fstest.MapFile{Data: []byte("official")}}
+	r := gin.New()
+	r.NoRoute(fallbackToFrontend(embed))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/logo/../../../secret", nil))
+	require.NotEqual(t, "secret", rec.Body.String())
+}

--- a/service/singleton/komari-api-shim.js
+++ b/service/singleton/komari-api-shim.js
@@ -1,0 +1,366 @@
+/* Nezha -> Komari public API compatibility layer. Read-only by design. */
+;(() => {
+  'use strict';
+  if (window.__NEZHA_KOMARI_API_SHIM__) return;
+  window.__NEZHA_KOMARI_API_SHIM__ = '1.0.0';
+
+  const NativeFetch = window.fetch.bind(window);
+  const NativeXMLHttpRequest = window.XMLHttpRequest;
+  const NativeWebSocket = window.WebSocket;
+  const cfg = window.__NEZHA_KOMARI_COMPAT__ || {};
+  const state = { snapshot: null, snapshotPromise: null, settings: null, groups: null, listeners: new Set() };
+  const maxMetricRequests = 24;
+  const jsonHeaders = { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' };
+  const metricMap = {
+    'cpu.usage': 'cpu', 'load.average': 'load1', 'memory.used': 'memory',
+    'swap.used': 'swap', 'disk.used': 'disk', 'net.in.rate': 'net_in_speed',
+    'net.out.rate': 'net_out_speed', 'net.total.down': 'net_in_transfer',
+    'net.total.up': 'net_out_transfer', 'process.count': 'process_count',
+    'connections.tcp': 'tcp_conn', 'connections.udp': 'udp_conn',
+    'uptime': 'uptime', 'temperature': 'temperature', 'gpu.usage': 'gpu'
+  };
+
+  const asURL = input => new URL(typeof input === 'string' ? input : input.url, location.href);
+  const response = (data, status = 200) => new Response(JSON.stringify(data), { status, headers: jsonHeaders });
+  const rpcOK = (id, result) => ({ jsonrpc: '2.0', id: id == null ? null : id, result });
+  const rpcError = (id, code, message) => ({ jsonrpc: '2.0', id: id == null ? null : id, error: { code, message } });
+  const readonlyError = id => rpcError(id, -32601, 'Komari compatibility layer is read-only');
+  const unwrap = async r => {
+    const body = await r.json();
+    if (!r.ok || body?.success === false || body?.error) throw new Error(body?.error || `HTTP ${r.status}`);
+    return body?.data === undefined ? body : body.data;
+  };
+  const nativeJSON = async path => unwrap(await NativeFetch(path, { credentials: 'same-origin', cache: 'no-store' }));
+  const iso = value => {
+    const d = new Date(value || Date.now());
+    return Number.isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
+  };
+  const num = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+
+  if (cfg.wallpaper) {
+    Object.defineProperty(window, 'CustomBackgroundImage', { configurable: false, enumerable: true, writable: false, value: cfg.wallpaper });
+    Object.defineProperty(window, 'CustomMobileBackgroundImage', { configurable: false, enumerable: true, writable: false, value: cfg.wallpaper });
+  }
+
+  const isKomariAdminPath = value => {
+    const path = new URL(String(value || location.href), location.href).pathname.replace(/\/+$/, '') || '/';
+    return path === '/admin' || path === '/admin/login' || path === '/login';
+  };
+  const redirectKomariAdmin = value => {
+    if (!isKomariAdminPath(value)) return false;
+    location.assign('/dashboard');
+    return true;
+  };
+  const loginLabels = new Set(['login', 'sign in', 'log in', '登录', '登入', 'ログイン']);
+  const isKomariLoginControl = element => {
+    const control = element?.closest?.('a[href],button,[role="button"]');
+    if (!control) return false;
+    if (control.matches('a[href]') && isKomariAdminPath(control.href)) return true;
+    const aria = String(control.getAttribute('aria-label') || '').trim().toLowerCase();
+    const title = String(control.getAttribute('title') || '').trim().toLowerCase();
+    const text = String(control.innerText || control.textContent || '').trim().toLowerCase();
+    return loginLabels.has(aria) || loginLabels.has(title) || loginLabels.has(text);
+  };
+  document.addEventListener('click', event => {
+    const control = event.target?.closest?.('a[href],button,[role="button"]');
+    if (!control || !isKomariLoginControl(control)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    location.assign('/dashboard');
+  }, true);
+  const nativePushState = history.pushState.bind(history);
+  const nativeReplaceState = history.replaceState.bind(history);
+  history.pushState = function(stateValue, unused, url) {
+    if (url != null && redirectKomariAdmin(url)) return;
+    return nativePushState(stateValue, unused, url);
+  };
+  history.replaceState = function(stateValue, unused, url) {
+    if (url != null && redirectKomariAdmin(url)) return;
+    return nativeReplaceState(stateValue, unused, url);
+  };
+  window.addEventListener('popstate', () => redirectKomariAdmin(location.href));
+  if (isKomariAdminPath(location.href)) queueMicrotask(() => location.assign('/dashboard'));
+
+  async function groups() {
+    if (state.groups) return state.groups;
+    try {
+      const rows = await nativeJSON('/api/v1/server-group');
+      state.groups = {};
+      (rows || []).forEach(row => (row.servers || []).forEach(id => { state.groups[String(id)] = row.group?.name || 'Nezha'; }));
+    } catch (_) { state.groups = {}; }
+    return state.groups;
+  }
+
+  function nodeFromServer(s) {
+    const h = s?.host || {}, st = s?.state || {};
+    return {
+      uuid: String(s?.id ?? ''), name: String(s?.name || 'Unnamed'), cpu_name: (h.cpu || []).join(' / '),
+      virtualization: h.virtualization || '', arch: h.arch || '', cpu_cores: (h.cpu || []).length,
+      cpu_physical_cores: (h.cpu || []).length, os: h.platform || '', kernel_version: h.platform_version || '',
+      gpu_name: (h.gpu || []).join(' / '), region: s?.country_code || '', mem_total: num(h.mem_total),
+      swap_total: num(h.swap_total), disk_total: num(h.disk_total), version: h.version || '',
+      weight: num(s?.display_index), price: 0, billing_cycle: 0, auto_renewal: false, currency: '',
+      expired_at: null, group: 'Nezha', tags: s?.country_code || '', public_remark: s?.public_note || '',
+      hidden: false, traffic_limit: 0, traffic_limit_type: 'sum', created_at: '', updated_at: iso(s?.last_active)
+    };
+  }
+
+  function statusFromServer(s) {
+    const h = s?.host || {}, st = s?.state || {};
+    const last = new Date(s?.last_active || 0).getTime();
+    return {
+      client: String(s?.id ?? ''), time: iso(s?.last_active), updated_at: iso(s?.last_active),
+      online: !!st && Date.now() - last < 180000, cpu: num(st.cpu), gpu: num((st.gpu || [])[0]),
+      ram: num(st.mem_used), ram_total: num(h.mem_total), swap: num(st.swap_used), swap_total: num(h.swap_total),
+      load: num(st.load_1), load5: num(st.load_5), load15: num(st.load_15), temp: num(st.temperatures?.[0]?.Temperature),
+      disk: num(st.disk_used), disk_total: num(h.disk_total), net_in: num(st.net_in_speed), net_out: num(st.net_out_speed),
+      net_total_up: num(st.net_out_transfer), net_total_down: num(st.net_in_transfer), process: num(st.process_count),
+      connections: num(st.tcp_conn_count) + num(st.udp_conn_count), connections_udp: num(st.udp_conn_count),
+      uptime: num(st.uptime), version: h.version || '', message: '', ping: {}
+    };
+  }
+
+  function reportFromServer(s) {
+    const h = s?.host || {}, st = s?.state || {};
+    return {
+      uuid: String(s?.id ?? ''), updated_at: iso(s?.last_active),
+      cpu: { usage: num(st.cpu) }, gpu: { average_usage: num((st.gpu || [])[0]), count: (h.gpu || []).length, detailed_info: [] },
+      ram: { used: num(st.mem_used), total: num(h.mem_total) }, swap: { used: num(st.swap_used), total: num(h.swap_total) },
+      load: { load1: num(st.load_1), load5: num(st.load_5), load15: num(st.load_15) },
+      disk: { used: num(st.disk_used), total: num(h.disk_total) },
+      network: { down: num(st.net_in_speed), up: num(st.net_out_speed), totalUp: num(st.net_out_transfer), totalDown: num(st.net_in_transfer) },
+      process: num(st.process_count), connections: { tcp: num(st.tcp_conn_count), udp: num(st.udp_conn_count) },
+      uptime: num(st.uptime), temperature: st.temperatures || [], online: true
+    };
+  }
+
+  function mergeNezhaSnapshot(data) {
+    if (!data?.servers) return data;
+    if (!state.snapshot?.servers) return data;
+    const previous = new Map(state.snapshot.servers.map(server => [String(server.id), server]));
+    return { ...state.snapshot, ...data, servers: data.servers.map(server => {
+      const old = previous.get(String(server.id)) || {};
+      return {
+        ...old, ...server,
+        host: server.host && Object.keys(server.host).length ? { ...(old.host || {}), ...server.host } : (old.host || server.host),
+        state: server.state && Object.keys(server.state).length ? { ...(old.state || {}), ...server.state } : (old.state || server.state),
+        public_note: server.public_note || old.public_note || ''
+      };
+    }) };
+  }
+
+  function acceptSnapshot(data) {
+    if (!data?.servers) return;
+    state.snapshot = mergeNezhaSnapshot(data);
+    state.snapshotPromise = Promise.resolve(state.snapshot);
+    state.listeners.forEach(fn => { try { fn(state.snapshot); } catch (_) {} });
+  }
+
+  function startNezhaStream() {
+    if (!NativeWebSocket || state.streamStarted) return;
+    state.streamStarted = true;
+    const connect = () => {
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const ws = new NativeWebSocket(`${proto}//${location.host}/api/v1/ws/server`);
+      ws.onmessage = ev => { try { acceptSnapshot(JSON.parse(ev.data)); } catch (_) {} };
+      ws.onclose = () => setTimeout(connect, 3000);
+      ws.onerror = () => { try { ws.close(); } catch (_) {} };
+    };
+    connect();
+  }
+
+  async function snapshot() {
+    startNezhaStream();
+    if (state.snapshot) return state.snapshot;
+    if (!state.snapshotPromise) state.snapshotPromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Nezha server stream timeout')), 10000);
+      const done = data => { clearTimeout(timer); state.listeners.delete(done); resolve(data); };
+      state.listeners.add(done);
+    });
+    return state.snapshotPromise;
+  }
+
+  async function publicSettings() {
+    if (state.settings) return state.settings;
+    const data = await nativeJSON('/api/v1/setting');
+    const c = data?.config || data || {};
+    state.settings = {
+      sitename: c.site_name || document.title || 'Nezha', description: c.description || '', custom_head: '', custom_body: '',
+      oauth_enable: false, oauth_provider: '', disable_password_login: false, record_enabled: !!data?.tsdb_enabled,
+      record_preserve_time: data?.tsdb_enabled ? 24 : 0, ping_record_preserve_time: data?.tsdb_enabled ? 24 : 0,
+      private_site: false, visitor_audit_enabled: false, theme: cfg.short || 'nezha-komari', theme_settings: cfg.theme_settings || {}
+    };
+    return state.settings;
+  }
+
+  async function nodes() {
+    const [snap, groupMap] = await Promise.all([snapshot(), groups()]);
+    const out = {};
+    (snap.servers || []).forEach(s => {
+      const node = nodeFromServer(s);
+      node.group = groupMap[String(s.id)] || node.group;
+      out[String(s.id)] = node;
+    });
+    return out;
+  }
+
+  async function statuses(params = {}) {
+    const snap = await snapshot(), wanted = params.uuid ? [String(params.uuid)] : (params.uuids || []).map(String), out = {};
+    (snap.servers || []).forEach(s => { if (!wanted.length || wanted.includes(String(s.id))) out[String(s.id)] = statusFromServer(s); });
+    return params.uuid ? out[String(params.uuid)] : out;
+  }
+
+  function periodForHours(hours) { return num(hours) > 24 ? '7d' : '1d'; }
+  async function metricSeries(entity, komariMetric, hours) {
+    const nezhaMetric = metricMap[komariMetric];
+    if (!nezhaMetric) return { metric_key: komariMetric, entity_id: String(entity), downsampled: false, count: 0, points: [] };
+    try {
+      const data = await nativeJSON(`/api/v1/server/${encodeURIComponent(entity)}/metrics?metric=${encodeURIComponent(nezhaMetric)}&period=${periodForHours(hours)}`);
+      const points = (data?.data_points || []).map(p => ({ time: iso(num(p.ts) < 1e12 ? num(p.ts) * 1000 : p.ts), value: num(p.value), count: 1 }));
+      return { metric_key: komariMetric, entity_id: String(entity), downsampled: false, count: points.length, points };
+    } catch (_) { return { metric_key: komariMetric, entity_id: String(entity), downsampled: false, count: 0, points: [] }; }
+  }
+
+  async function queryMetrics(params = {}) {
+    const metrics = [...new Set([...(params.metric_keys || params.metrics || []), ...(params.metric_key ? [params.metric_key] : [])])];
+    const entities = [...new Set([...(params.entity_ids || []), ...(params.entity_id ? [params.entity_id] : [])])];
+    const ids = entities.length ? entities : Object.keys(await nodes());
+    const jobs = ids.flatMap(id => metrics.map(metric => [id, metric]));
+    const out = [];
+    // Avoid hundreds/thousands of simultaneous TSDB requests on large fleets.
+    for (let i = 0; i < jobs.length; i += maxMetricRequests) {
+      const batch = jobs.slice(i, i + maxMetricRequests);
+      out.push(...await Promise.all(batch.map(([id, metric]) => metricSeries(id, metric, params.hours || 24))));
+    }
+    return out;
+  }
+
+  async function recent(uuid) {
+    const snap = await snapshot(), server = (snap.servers || []).find(s => String(s.id) === String(uuid));
+    return server ? [reportFromServer(server)] : [];
+  }
+
+  async function records(params = {}) {
+    const metricKeys = ['cpu.usage','load.average','memory.used','swap.used','disk.used','net.in.rate','net.out.rate','net.total.down','net.total.up','process.count','connections.tcp','connections.udp'];
+    const series = await queryMetrics({ entity_id: params.uuid, metric_keys: metricKeys, hours: params.hours || 4 });
+    const rows = new Map();
+    const fields = { 'cpu.usage':'cpu','load.average':'load','memory.used':'ram','swap.used':'swap','disk.used':'disk','net.in.rate':'net_in','net.out.rate':'net_out','net.total.down':'net_total_down','net.total.up':'net_total_up','process.count':'process','connections.tcp':'connections','connections.udp':'connections_udp' };
+    series.forEach(s => (s.points || []).forEach(p => { const key = p.time; const row = rows.get(key) || { client:String(params.uuid), time:key }; row[fields[s.metric_key]] = p.value; rows.set(key,row); }));
+    return { records: [...rows.values()].sort((a,b) => new Date(a.time)-new Date(b.time)), count: rows.size, has_gpu_data: false };
+  }
+
+  async function rpcDispatch(call) {
+    const method = call?.method || '', p = call?.params || {}, id = call?.id;
+    try {
+      let result;
+      switch (method) {
+        case 'rpc.ping': result = 'pong'; break;
+        case 'rpc.getVersion': case 'common:getBackendVersion': result = { version:'nezha-komari-compat', hash:'' }; break;
+        case 'rpc.getMethods': result = ['rpc.ping','rpc.getVersion','rpc.getMethods','rpc.getHelp','common:getPublicInfo','common:getNodes','common:getNodesLatestStatus','common:getNodeRecentStatus','common:getRecords']; break;
+        case 'rpc.getHelp': result = { name:'Nezha Komari compatibility layer', read_only:true }; break;
+        case 'common:getPublicInfo': case 'public:getPublicSettings': result = await publicSettings(); break;
+        case 'common:getMe': case 'public:getMe': result = { username:'Guest', logged_in:false }; break;
+        case 'common:getVersion': case 'public:getVersion': result = { version:'nezha-komari-compat', hash:'' }; break;
+        case 'common:getNodes': case 'public:getNodesInformation': result = await nodes(); if (method.startsWith('public:')) result = Object.values(result); break;
+        case 'common:getNodesLatestStatus': result = await statuses(p); break;
+        case 'common:getNodeRecentStatus': case 'public:getClientRecentRecords': result = await recent(p.uuid); break;
+        case 'common:getRecords': case 'public:getRecordsByUUID': result = await records(p); break;
+        case 'public:queryMetrics': result = await queryMetrics(p); break;
+        case 'public:listMetricDefinitions': result = Object.keys(metricMap).map(name => ({ name, type:'gauge', unit:'', retention_days:1 })); break;
+        case 'public:getPublicPingTasks': result = []; break;
+        case 'public:getPingRecords': result = { count:0, records:[], tasks:[] }; break;
+        case 'public:getPingMetricStats': result = { start:iso(), end:iso(), stats:[], count:0 }; break;
+        case 'public:recordVisitorEvent': result = { accepted:true }; break;
+        default: return readonlyError(id);
+      }
+      return rpcOK(id, result);
+    } catch (error) { return rpcError(id, -32000, error?.message || 'compatibility error'); }
+  }
+
+  async function rpcHTTP(request) {
+    const body = JSON.parse(await request.text() || '{}');
+    if (Array.isArray(body)) return response(await Promise.all(body.map(rpcDispatch)));
+    return response(await rpcDispatch(body));
+  }
+
+  async function shimFetch(input, init) {
+    const req = new Request(input, init), url = asURL(req), path = url.pathname;
+    if (url.origin !== location.origin || !path.startsWith('/api/')) return NativeFetch(input, init);
+    if (path === '/api/rpc2' && req.method === 'POST') return rpcHTTP(req);
+    if (path === '/api/public') return response({ status:'success', message:'ok', data:await publicSettings() });
+    if (path === '/api/me') return response({ username:'Guest', logged_in:false });
+    if (path === '/api/version') return response({ version:'nezha-komari-compat', hash:'' });
+    if (path === '/api/admin/theme/settings') {
+      if (req.method === 'GET') return response({ status:'success', message:'ok', data:cfg.theme_settings || {} });
+      return response({ status:'error', message:'Komari compatibility layer is read-only' }, 405);
+    }
+    if (path.startsWith('/api/recent/')) return response({ status:'success', message:'ok', data:await recent(decodeURIComponent(path.slice(12))) });
+    if (path === '/api/records/load') return response(await records({ uuid:url.searchParams.get('uuid'), hours:url.searchParams.get('hours') }));
+    if (path === '/api/records/ping') return response({ count:0, records:[], tasks:[] });
+    if (path === '/api/nodes') return response(Object.values(await nodes()));
+    if (req.method !== 'GET' && req.method !== 'HEAD') return response({ error:'read only' }, 405);
+    return NativeFetch(input, init);
+  }
+
+  class KomariXMLHttpRequest extends EventTarget {
+    constructor() {
+      super(); this.readyState=0; this.status=0; this.statusText=''; this.responseText=''; this.response=null; this.responseType=''; this.timeout=0; this.withCredentials=false; this.upload=new EventTarget(); this.headers={};
+    }
+    open(method,url,async=true,user,password){ this.method=method;this.url=String(url);this.async=async!==false;this.readyState=1;this.onreadystatechange?.(new Event('readystatechange')); }
+    setRequestHeader(name,value){ this.headers[name]=value; }
+    getAllResponseHeaders(){ return 'content-type: application/json; charset=utf-8\r\n'; }
+    getResponseHeader(name){ return String(name).toLowerCase()==='content-type'?'application/json; charset=utf-8':null; }
+    abort(){ this.aborted=true;this.readyState=0;this.onabort?.(new Event('abort')); }
+    send(body=null){
+      if (this.aborted) return;
+      const init={method:this.method||'GET',headers:this.headers,body:/^(GET|HEAD)$/i.test(this.method||'GET')?undefined:body,credentials:this.withCredentials?'include':'same-origin'};
+      shimFetch(this.url,init).then(async res=>{
+        if(this.aborted)return;this.status=res.status;this.statusText=res.statusText;this.responseText=await res.text();
+        this.response=this.responseType==='json'?JSON.parse(this.responseText||'null'):this.responseText;this.readyState=4;
+        const change=new Event('readystatechange');this.dispatchEvent(change);this.onreadystatechange?.(change);
+        const event=new Event(res.ok?'load':'error');this.dispatchEvent(event);(res.ok?this.onload:this.onerror)?.(event);this.onloadend?.(new Event('loadend'));
+      }).catch(error=>{if(this.aborted)return;this.status=0;this.statusText=String(error);this.readyState=4;const event=new Event('error');this.dispatchEvent(event);this.onerror?.(event);this.onloadend?.(new Event('loadend'));});
+    }
+  }
+  Object.assign(KomariXMLHttpRequest,{UNSENT:0,OPENED:1,HEADERS_RECEIVED:2,LOADING:3,DONE:4});
+  Object.assign(KomariXMLHttpRequest.prototype,{UNSENT:0,OPENED:1,HEADERS_RECEIVED:2,LOADING:3,DONE:4});
+
+  class KomariRPCWebSocket extends EventTarget {
+    static CONNECTING=0; static OPEN=1; static CLOSING=2; static CLOSED=3;
+    constructor(url) {
+      super(); this.url=String(url); this.readyState=0; this.protocol=''; this.extensions=''; this.bufferedAmount=0; this.binaryType='blob';
+      queueMicrotask(() => { this.readyState=1; const e=new Event('open'); this.dispatchEvent(e); this.onopen?.(e); });
+    }
+    send(data) { Promise.resolve().then(async()=>{ const call=JSON.parse(data); const answer=await rpcDispatch(call); const e=new MessageEvent('message',{data:JSON.stringify(answer)}); this.dispatchEvent(e); this.onmessage?.(e); }); }
+    close() { if(this.readyState>=2)return; this.readyState=3; const e=new CloseEvent('close',{code:1000,reason:'',wasClean:true}); this.dispatchEvent(e); this.onclose?.(e); }
+    addEventListener(...args){ return super.addEventListener(...args); }
+  }
+
+  class KomariClientsWebSocket extends EventTarget {
+    static CONNECTING=0; static OPEN=1; static CLOSING=2; static CLOSED=3;
+    constructor(url) {
+      super(); this.url=String(url); this.readyState=0; this.protocol=''; this.extensions=''; this.bufferedAmount=0; this.binaryType='blob';
+      queueMicrotask(() => { this.readyState=1; const e=new Event('open'); this.dispatchEvent(e); this.onopen?.(e); });
+    }
+    send(command) { Promise.resolve().then(async()=>{
+      const text=String(command||'').trim(), wanted=text.startsWith('get ')?text.slice(4).trim():'';
+      const snap=await snapshot(), online=[], data={};
+      (snap.servers||[]).forEach(server=>{const id=String(server.id);if(wanted&&id!==wanted)return;const status=statusFromServer(server);if(status.online)online.push(id);data[id]=reportFromServer(server)});
+      const e=new MessageEvent('message',{data:JSON.stringify({status:'success',data:{online,data}})});this.dispatchEvent(e);this.onmessage?.(e);
+    }); }
+    close() { if(this.readyState>=2)return; this.readyState=3; const e=new CloseEvent('close',{code:1000,reason:'',wasClean:true}); this.dispatchEvent(e); this.onclose?.(e); }
+  }
+
+  window.fetch = shimFetch;
+  window.XMLHttpRequest = KomariXMLHttpRequest;
+  window.WebSocket = function(url, protocols) {
+    const u = asURL(url);
+    if (u.origin === location.origin && u.pathname === '/api/rpc2') return new KomariRPCWebSocket(url, protocols);
+    if (u.origin === location.origin && u.pathname === '/api/clients') return new KomariClientsWebSocket(url, protocols);
+    return new NativeWebSocket(url, protocols);
+  };
+  Object.assign(window.WebSocket, { CONNECTING:0, OPEN:1, CLOSING:2, CLOSED:3 });
+  window.WebSocket.prototype = NativeWebSocket.prototype;
+  window.__NEZHA_KOMARI_COMPAT_API__ = { nodeFromServer, statusFromServer, reportFromServer, rpcDispatch };
+  startNezhaStream();
+})();

--- a/service/singleton/komari-theme-market-v1.json
+++ b/service/singleton/komari-theme-market-v1.json
@@ -1,0 +1,17 @@
+{
+  "schema": 1,
+  "updated_at": "2026-08-09T13:15:53.760Z",
+  "themes": [
+    {
+      "name": "Komari Glassmorphism",
+      "short": "Glassmorphism",
+      "description": "A Glassmorphism theme for Komari",
+      "version": "3.3.3",
+      "author": "sanrokamlan",
+      "url": "https://github.com/sanrokamlan-prog/komari-theme-Glassmorphism",
+      "preview": "https://raw.githubusercontent.com/sanrokamlan-prog/komari-theme-Glassmorphism/refs/heads/main/docs/preview.png",
+      "download": "https://github.com/sanrokamlan-prog/komari-theme-Glassmorphism/releases/download/v3.3.3/komari-theme-Glassmorphism-build-63a1d01.zip",
+      "sha256": "01a1d0111b0405f0ffaa280070d77e0dfe46bdd728edf0dbe7396a93be3ff249"
+    }
+  ]
+}

--- a/service/singleton/komari_api_shim.go
+++ b/service/singleton/komari_api_shim.go
@@ -1,0 +1,84 @@
+package singleton
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+//go:embed komari-api-shim.js
+var komariAPIShim []byte
+
+func KomariAPIShimJS() []byte {
+	return append([]byte(nil), komariAPIShim...)
+}
+
+func InjectKomariCompatibility(document []byte, templatePath, wallpaper string) []byte {
+	config, _ := json.Marshal(map[string]any{
+		"short":          strings.TrimPrefix(templatePath, "komari-market-"),
+		"template_path":  templatePath,
+		"wallpaper":      wallpaper,
+		"theme_settings": map[string]any{},
+	})
+	shim := `<script id="nezha-komari-api-shim">window.__NEZHA_KOMARI_COMPAT__=` + string(config) + `;</script><script>` + string(komariAPIShim) + `</script>`
+	text := string(document)
+	if pos := strings.Index(strings.ToLower(text), "<script"); pos >= 0 {
+		return []byte(text[:pos] + shim + text[pos:])
+	}
+	if pos := strings.Index(strings.ToLower(text), "</head>"); pos >= 0 {
+		return []byte(text[:pos] + shim + text[pos:])
+	}
+	return append([]byte(shim), document...)
+}
+
+type komariShimServerFixture struct {
+	ID         uint64    `json:"id"`
+	Name       string    `json:"name"`
+	LastActive time.Time `json:"last_active"`
+	Host       struct {
+		Platform       string   `json:"platform"`
+		CPU            []string `json:"cpu"`
+		MemTotal       int64    `json:"mem_total"`
+		DiskTotal      int64    `json:"disk_total"`
+		SwapTotal      int64    `json:"swap_total"`
+		Arch           string   `json:"arch"`
+		Virtualization string   `json:"virtualization"`
+	} `json:"host"`
+	State struct {
+		CPU            float64 `json:"cpu"`
+		MemUsed        int64   `json:"mem_used"`
+		NetOutTransfer int64   `json:"net_out_transfer"`
+	} `json:"state"`
+}
+
+type KomariShimFixtureResult struct {
+	UUID     string
+	Name     string
+	OS       string
+	MemTotal int64
+	Status   struct {
+		CPU        float64
+		RAM        int64
+		NetTotalUp int64
+		Online     bool
+	}
+}
+
+func KomariShimConvertServerFixture(raw []byte) (KomariShimFixtureResult, error) {
+	var src komariShimServerFixture
+	if err := json.Unmarshal(raw, &src); err != nil {
+		return KomariShimFixtureResult{}, err
+	}
+	var out KomariShimFixtureResult
+	out.UUID = fmt.Sprint(src.ID)
+	out.Name = src.Name
+	out.OS = src.Host.Platform
+	out.MemTotal = src.Host.MemTotal
+	out.Status.CPU = src.State.CPU
+	out.Status.RAM = src.State.MemUsed
+	out.Status.NetTotalUp = src.State.NetOutTransfer
+	out.Status.Online = time.Since(src.LastActive) < 3*time.Minute
+	return out, nil
+}

--- a/service/singleton/komari_api_shim_test.go
+++ b/service/singleton/komari_api_shim_test.go
@@ -1,0 +1,108 @@
+package singleton
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKomariAPIShimInterceptsPublicReadOnlyContracts(t *testing.T) {
+	shim := string(KomariAPIShimJS())
+	for _, needle := range []string{
+		"/api/rpc2",
+		"/api/public",
+		"/api/me",
+		"/api/recent/",
+		"/api/records/load",
+		"/api/records/ping",
+		"rpc.ping",
+		"rpc.getVersion",
+		"rpc.getMethods",
+		"rpc.getHelp",
+		"common:getBackendVersion",
+		"common:getNodes",
+		"common:getNodesLatestStatus",
+		"public:getPublicSettings",
+		"public:getNodesInformation",
+		"public:getClientRecentRecords",
+		"public:getRecordsByUUID",
+		"public:queryMetrics",
+		"public:getPingRecords",
+		"public:getPublicPingTasks",
+	} {
+		require.Contains(t, shim, needle)
+	}
+	require.Contains(t, shim, "class KomariRPCWebSocket")
+	require.Contains(t, shim, "window.fetch")
+	require.Contains(t, shim, "window.XMLHttpRequest")
+	require.Contains(t, shim, "class KomariXMLHttpRequest")
+	require.Contains(t, shim, "window.WebSocket")
+	require.Contains(t, shim, "mergeNezhaSnapshot")
+	require.Contains(t, shim, "maxMetricRequests")
+	require.Contains(t, shim, "u.origin === location.origin && u.pathname === '/api/rpc2'")
+	require.Contains(t, shim, "u.origin === location.origin && u.pathname === '/api/clients'")
+	require.Contains(t, shim, "/api/admin/theme/settings")
+	require.Contains(t, shim, "redirectKomariAdmin")
+	require.Contains(t, shim, "history.pushState")
+	require.Contains(t, shim, "'/dashboard'")
+	require.Contains(t, shim, "isKomariLoginControl")
+	require.Contains(t, shim, "aria-label")
+	for _, label := range []string{"login", "sign in", "登录", "登入", "ログイン"} {
+		require.Contains(t, shim, label)
+	}
+}
+
+func TestKomariAPIShimUsesOnlyNezhaGuestReadEndpoints(t *testing.T) {
+	shim := string(KomariAPIShimJS())
+	for _, allowed := range []string{
+		"/api/v1/setting",
+		"/api/v1/server-group",
+		"/api/v1/ws/server",
+		"/api/v1/server/",
+	} {
+		require.Contains(t, shim, allowed)
+	}
+	for _, forbidden := range []string{
+		"/api/v1/terminal",
+		"/api/v1/file",
+		"/api/v1/batch-delete",
+		"Authorization: Bearer",
+		"localStorage.getItem('token')",
+	} {
+		require.NotContains(t, shim, forbidden)
+	}
+}
+
+func TestKomariAPIShimDoesNotFakeAdminWrites(t *testing.T) {
+	shim := string(KomariAPIShimJS())
+	require.Contains(t, shim, "readonlyError")
+	require.Contains(t, shim, "-32601")
+	require.NotContains(t, shim, "admin:update")
+}
+
+func TestInjectKomariCompatibilityRunsBeforeThemeAssets(t *testing.T) {
+	html := []byte(`<html><head><script type="module" src="/assets/theme.js"></script></head><body></body></html>`)
+	out := string(InjectKomariCompatibility(html, "market-theme", "https://cdn.example/wall.webp"))
+	shimAt := strings.Index(out, "nezha-komari-api-shim")
+	themeAt := strings.Index(out, `/assets/theme.js`)
+	require.GreaterOrEqual(t, shimAt, 0)
+	require.Greater(t, themeAt, shimAt)
+	require.Contains(t, out, "https://cdn.example/wall.webp")
+}
+
+func TestKomariShimNodeFixtureConversion(t *testing.T) {
+	serverJSON := fmt.Sprintf(`{"id":7,"name":"alpha","host":{"platform":"linux","cpu":["AMD"],"mem_total":1024,"disk_total":2048,"swap_total":128,"arch":"amd64","virtualization":"kvm"},"state":{"cpu":25.5,"mem_used":512,"disk_used":1000,"swap_used":64,"net_in_speed":11,"net_out_speed":22,"net_in_transfer":33,"net_out_transfer":44,"uptime":55,"load_1":1.2,"load_5":0.8,"load_15":0.4,"tcp_conn_count":5,"udp_conn_count":2,"process_count":99},"country_code":"JP","last_active":%q}`, time.Now().UTC().Format(time.RFC3339))
+	got, err := KomariShimConvertServerFixture([]byte(serverJSON))
+	require.NoError(t, err)
+	require.Equal(t, "7", got.UUID)
+	require.Equal(t, "alpha", got.Name)
+	require.Equal(t, "linux", got.OS)
+	require.Equal(t, int64(1024), got.MemTotal)
+	require.Equal(t, 25.5, got.Status.CPU)
+	require.Equal(t, int64(512), got.Status.RAM)
+	require.Equal(t, int64(44), got.Status.NetTotalUp)
+	require.True(t, got.Status.Online)
+}

--- a/service/singleton/komari_theme_install.go
+++ b/service/singleton/komari_theme_install.go
@@ -1,0 +1,179 @@
+package singleton
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	maxKomariThemeArchiveBytes = 128 << 20
+	maxKomariThemeExtractBytes = 512 << 20
+	maxKomariThemeFiles        = 10000
+)
+
+func komariThemeDir() string {
+	if root := strings.TrimSpace(os.Getenv("NZ_KOMARI_THEME_DIR")); root != "" {
+		return root
+	}
+	return filepath.Join("data", "komari-themes")
+}
+
+func KomariThemeInstallDir() string { return komariThemeDir() }
+
+func installedKomariThemeDist(templatePath string) (string, bool) {
+	if !strings.HasPrefix(templatePath, "komari-market-") || komariTemplatePath(strings.TrimPrefix(templatePath, "komari-market-")) != templatePath {
+		return "", false
+	}
+	dist := filepath.Join(komariThemeDir(), templatePath, "dist")
+	info, err := os.Stat(filepath.Join(dist, "index.html"))
+	return dist, err == nil && !info.IsDir()
+}
+
+func installKomariThemeArchive(root, templatePath string, meta KomariThemeMetadata, data []byte) (string, error) {
+	if len(data) == 0 || len(data) > maxKomariThemeArchiveBytes {
+		return "", fmt.Errorf("theme archive size invalid")
+	}
+	sum := sha256.Sum256(data)
+	if !strings.EqualFold(hex.EncodeToString(sum[:]), meta.SHA256) {
+		return "", fmt.Errorf("theme archive sha256 mismatch")
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", err
+	}
+	if len(zr.File) > maxKomariThemeFiles {
+		return "", fmt.Errorf("theme archive has too many files")
+	}
+	target := filepath.Join(root, templatePath)
+	tmp, err := os.MkdirTemp(root, ".komari-install-")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmp)
+	var total uint64
+	for _, f := range zr.File {
+		name := filepath.Clean(filepath.FromSlash(f.Name))
+		if name == "." {
+			continue
+		}
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(os.PathSeparator)) || f.Mode()&os.ModeSymlink != 0 {
+			return "", fmt.Errorf("unsafe theme archive path %q", f.Name)
+		}
+		total += f.UncompressedSize64
+		if total > maxKomariThemeExtractBytes {
+			return "", fmt.Errorf("theme archive extracted size exceeds limit")
+		}
+		out := filepath.Join(tmp, name)
+		rel, err := filepath.Rel(tmp, out)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			return "", fmt.Errorf("unsafe theme archive path %q", f.Name)
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(out, 0o755); err != nil {
+				return "", err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			return "", err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", err
+		}
+		dst, err := os.OpenFile(out, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+		if err != nil {
+			rc.Close()
+			return "", err
+		}
+		_, copyErr := io.Copy(dst, io.LimitReader(rc, int64(f.UncompressedSize64)+1))
+		closeErr := dst.Close()
+		rc.Close()
+		if copyErr != nil {
+			return "", copyErr
+		}
+		if closeErr != nil {
+			return "", closeErr
+		}
+	}
+	if info, err := os.Stat(filepath.Join(tmp, "dist", "index.html")); err != nil || info.IsDir() {
+		return "", fmt.Errorf("theme archive missing dist/index.html")
+	}
+	if err := os.WriteFile(filepath.Join(tmp, ".nezha-komari-version"), []byte(meta.Version+"\n"+meta.SHA256+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return "", err
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		return "", err
+	}
+	return filepath.Join(target, "dist"), nil
+}
+
+func ensureKomariThemeInstalled(templatePath string) (string, error) {
+	komariThemeMu.RLock()
+	meta, ok := KomariThemeCatalog[templatePath]
+	komariThemeMu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("unknown Komari theme")
+	}
+	if dist, ok := installedKomariThemeDist(templatePath); ok {
+		marker, err := os.ReadFile(filepath.Join(komariThemeDir(), templatePath, ".nezha-komari-version"))
+		if err == nil && strings.Contains(string(marker), meta.SHA256) {
+			return dist, nil
+		}
+	}
+	client := &http.Client{Timeout: 45 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, meta.Download, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Nezha-Dashboard-Komari-Theme/1")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("theme download HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxKomariThemeArchiveBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(data) > maxKomariThemeArchiveBytes {
+		return "", fmt.Errorf("theme archive exceeds limit")
+	}
+	if err := os.MkdirAll(komariThemeDir(), 0o755); err != nil {
+		return "", err
+	}
+	return installKomariThemeArchive(komariThemeDir(), templatePath, meta, data)
+}
+
+func syncKomariThemes() {
+	// Tests and restricted startup paths can initialize the template catalog
+	// before the dashboard config exists.
+	if Conf == nil || Conf.Config == nil {
+		return
+	}
+	// Install only the currently selected theme. Installing the entire market at
+	// startup wastes bandwidth and expands the third-party code surface.
+	selected := strings.TrimSpace(Conf.UserTemplate)
+	if !strings.HasPrefix(selected, "komari-market-") {
+		return
+	}
+	if _, err := ensureKomariThemeInstalled(selected); err != nil {
+		log.Printf("NEZHA>> Komari theme %s install failed; using official fallback: %v", selected, err)
+	}
+}

--- a/service/singleton/komari_theme_install_test.go
+++ b/service/singleton/komari_theme_install_test.go
@@ -1,0 +1,84 @@
+package singleton
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func themeZipFixture(t *testing.T, files map[string]string) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, body := range files {
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}
+
+func TestInstallKomariThemeArchiveVerifiesDigestAndExtractsDist(t *testing.T) {
+	data, digest := themeZipFixture(t, map[string]string{
+		"dist/index.html":    `<html><head><script src="/assets/app.js"></script></head></html>`,
+		"dist/assets/app.js": `window.realKomariTheme=true`,
+		"komari-theme.json":  `{"short":"future"}`,
+	})
+	root := t.TempDir()
+	path, err := installKomariThemeArchive(root, "komari-market-future", KomariThemeMetadata{Short: "future", SHA256: digest, Version: "1"}, data)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(root, "komari-market-future", "dist"), path)
+	require.FileExists(t, filepath.Join(path, "index.html"))
+	require.FileExists(t, filepath.Join(path, "assets", "app.js"))
+	require.FileExists(t, filepath.Join(root, "komari-market-future", ".nezha-komari-version"))
+}
+
+func TestInstallKomariThemeArchiveRejectsDigestMismatch(t *testing.T) {
+	data, _ := themeZipFixture(t, map[string]string{"dist/index.html": "ok"})
+	_, err := installKomariThemeArchive(t.TempDir(), "komari-market-bad", KomariThemeMetadata{Short: "bad", SHA256: string(make([]byte, 64))}, data)
+	require.ErrorContains(t, err, "sha256")
+}
+
+func TestInstallKomariThemeArchiveRejectsTraversalAndSymlinks(t *testing.T) {
+	data, digest := themeZipFixture(t, map[string]string{"../escape": "bad", "dist/index.html": "ok"})
+	_, err := installKomariThemeArchive(t.TempDir(), "komari-market-bad", KomariThemeMetadata{Short: "bad", SHA256: digest}, data)
+	require.ErrorContains(t, err, "unsafe")
+}
+
+func TestInstallKomariThemeArchiveRequiresDistIndex(t *testing.T) {
+	data, digest := themeZipFixture(t, map[string]string{"komari-theme.json": "{}"})
+	_, err := installKomariThemeArchive(t.TempDir(), "komari-market-bad", KomariThemeMetadata{Short: "bad", SHA256: digest}, data)
+	require.ErrorContains(t, err, "dist/index.html")
+}
+
+func TestSyncKomariThemesToleratesNilConfig(t *testing.T) {
+	original := Conf
+	Conf = nil
+	t.Cleanup(func() { Conf = original })
+	require.NotPanics(t, syncKomariThemes)
+}
+
+func TestResolveKomariFrontendTemplateUsesInstalledThemeDist(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("NZ_KOMARI_THEME_DIR", root)
+	path := filepath.Join(root, "komari-market-future", "dist")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(path, "index.html"), []byte("real theme"), 0o644))
+	KomariThemeCatalog = map[string]KomariThemeMetadata{"komari-market-future": {Short: "future", Preview: "https://cdn.example/p.png"}}
+	KomariThemeWallpapers = map[string]string{"komari-market-future": "https://cdn.example/p.png"}
+	t.Cleanup(func() { KomariThemeCatalog = nil; KomariThemeWallpapers = nil })
+
+	got, wallpaper, ok := ResolveKomariFrontendTemplate("komari-market-future")
+	require.True(t, ok)
+	require.Equal(t, path, got)
+	require.Equal(t, "https://cdn.example/p.png", wallpaper)
+}

--- a/service/singleton/komari_theme_market.go
+++ b/service/singleton/komari_theme_market.go
@@ -1,0 +1,237 @@
+package singleton
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"html"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nezhahq/nezha/model"
+)
+
+const defaultKomariThemeMarketURL = "https://raw.githubusercontent.com/komari-monitor/theme-market/main/v1.json"
+
+//go:embed komari-theme-market-v1.json
+var embeddedKomariThemeMarket []byte
+
+var (
+	komariThemeMu         sync.RWMutex
+	KomariThemeWallpapers map[string]string
+	KomariThemeCatalog    map[string]KomariThemeMetadata
+)
+
+type KomariThemeMetadata struct {
+	Short    string
+	Preview  string
+	Download string
+	SHA256   string
+	Version  string
+}
+
+type localizedText any
+
+type komariMarketCatalog struct {
+	Schema int `json:"schema"`
+	Themes []struct {
+		Name     localizedText `json:"name"`
+		Short    string        `json:"short"`
+		Version  string        `json:"version"`
+		Author   localizedText `json:"author"`
+		URL      string        `json:"url"`
+		Preview  string        `json:"preview"`
+		Download string        `json:"download"`
+		SHA256   string        `json:"sha256"`
+	} `json:"themes"`
+}
+
+var safeThemePart = regexp.MustCompile(`[^a-z0-9]+`)
+var sha256Hex = regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
+
+func localizedString(value localizedText) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case map[string]any:
+		for _, key := range []string{"zh-CN", "zh-TW", "en", "ja"} {
+			if text, ok := v[key].(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+		for _, raw := range v {
+			if text, ok := raw.(string); ok && strings.TrimSpace(text) != "" {
+				return strings.TrimSpace(text)
+			}
+		}
+	}
+	return ""
+}
+
+func httpsURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme == "https" && u.Host != ""
+}
+
+func komariTemplatePath(short string) string {
+	part := strings.Trim(safeThemePart.ReplaceAllString(strings.ToLower(strings.TrimSpace(short)), "-"), "-")
+	if part == "" {
+		return ""
+	}
+	return "komari-market-" + part
+}
+
+func parseKomariThemeMarket(r io.Reader) ([]model.FrontendTemplate, map[string]KomariThemeMetadata, error) {
+	dec := json.NewDecoder(io.LimitReader(r, 2<<20))
+	dec.UseNumber()
+	var catalog komariMarketCatalog
+	if err := dec.Decode(&catalog); err != nil {
+		return nil, nil, err
+	}
+	if catalog.Schema != 1 {
+		return nil, nil, fmt.Errorf("unsupported Komari theme market schema %d", catalog.Schema)
+	}
+
+	seen := make(map[string]struct{})
+	templates := make([]model.FrontendTemplate, 0, len(catalog.Themes))
+	themes := make(map[string]KomariThemeMetadata)
+	for _, theme := range catalog.Themes {
+		path := komariTemplatePath(theme.Short)
+		name := localizedString(theme.Name)
+		author := localizedString(theme.Author)
+		if path == "" || name == "" || author == "" || theme.Version == "" ||
+			!httpsURL(theme.URL) || !httpsURL(theme.Preview) || !httpsURL(theme.Download) ||
+			!sha256Hex.MatchString(theme.SHA256) {
+			continue
+		}
+		if _, exists := seen[path]; exists {
+			continue
+		}
+		seen[path] = struct{}{}
+		templates = append(templates, model.FrontendTemplate{
+			Path: path, Name: name, Repository: theme.URL, Author: author, Version: theme.Version,
+		})
+		themes[path] = KomariThemeMetadata{Short: theme.Short, Preview: theme.Preview, Download: theme.Download, SHA256: strings.ToLower(theme.SHA256), Version: theme.Version}
+	}
+	sort.SliceStable(templates, func(i, j int) bool { return templates[i].Name < templates[j].Name })
+	return templates, themes, nil
+}
+
+func komariMarketCachePath() string {
+	if path := strings.TrimSpace(os.Getenv("NZ_KOMARI_THEME_MARKET_CACHE")); path != "" {
+		return path
+	}
+	return filepath.Join("data", "komari-theme-market-v1.json")
+}
+
+func fetchKomariThemeMarket() ([]byte, error) {
+	marketURL := strings.TrimSpace(os.Getenv("NZ_KOMARI_THEME_MARKET_URL"))
+	if marketURL == "" {
+		marketURL = defaultKomariThemeMarketURL
+	}
+	if !httpsURL(marketURL) {
+		return nil, fmt.Errorf("Komari theme market URL must use HTTPS")
+	}
+	client := &http.Client{Timeout: 8 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, marketURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Nezha-Dashboard-Komari-Catalog/1")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("theme market HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, (2<<20)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > 2<<20 {
+		return nil, fmt.Errorf("theme market exceeds 2 MiB")
+	}
+	return data, nil
+}
+
+func loadKomariThemeMarket() ([]model.FrontendTemplate, map[string]KomariThemeMetadata, string, error) {
+	if data, err := fetchKomariThemeMarket(); err == nil {
+		if templates, wallpapers, parseErr := parseKomariThemeMarket(strings.NewReader(string(data))); parseErr == nil && len(templates) > 0 {
+			cache := komariMarketCachePath()
+			if mkErr := os.MkdirAll(filepath.Dir(cache), 0o755); mkErr == nil {
+				if writeErr := os.WriteFile(cache, data, 0o644); writeErr != nil {
+					log.Printf("NEZHA>> write Komari market cache: %v", writeErr)
+				}
+			}
+			return templates, wallpapers, "remote", nil
+		}
+	}
+	if data, err := os.ReadFile(komariMarketCachePath()); err == nil {
+		if templates, wallpapers, parseErr := parseKomariThemeMarket(strings.NewReader(string(data))); parseErr == nil && len(templates) > 0 {
+			return templates, wallpapers, "cache", nil
+		}
+	}
+	templates, wallpapers, err := parseKomariThemeMarket(strings.NewReader(string(embeddedKomariThemeMarket)))
+	return templates, wallpapers, "embedded", err
+}
+
+func appendKomariThemeMarketTemplates(base []model.FrontendTemplate) []model.FrontendTemplate {
+	templates, wallpapers, source, err := loadKomariThemeMarket()
+	if err != nil {
+		log.Printf("NEZHA>> Komari theme market unavailable: %v", err)
+		return base
+	}
+	komariThemeMu.Lock()
+	KomariThemeCatalog = wallpapers
+	KomariThemeWallpapers = make(map[string]string, len(wallpapers))
+	for path, theme := range wallpapers {
+		KomariThemeWallpapers[path] = theme.Preview
+	}
+	komariThemeMu.Unlock()
+	log.Printf("NEZHA>> Loaded %d Komari wallpaper templates from %s catalog", len(templates), source)
+	return append(base, templates...)
+}
+
+// ResolveKomariFrontendTemplate maps a dynamic catalog item to the official Nezha frontend.
+// Komari packages target a different API, so only their catalog preview is used as wallpaper.
+func ResolveKomariFrontendTemplate(path string) (templateRoot, wallpaper string, ok bool) {
+	komariThemeMu.RLock()
+	wallpaper, ok = KomariThemeWallpapers[path]
+	komariThemeMu.RUnlock()
+	if !ok {
+		return "", "", false
+	}
+	if dist, installed := installedKomariThemeDist(path); installed {
+		return dist, wallpaper, true
+	}
+	return "user-dist", wallpaper, true
+}
+
+func InjectKomariWallpaper(document []byte, wallpaper, templatePath string) []byte {
+	return injectKomariWallpaper(document, wallpaper, templatePath)
+}
+
+func injectKomariWallpaper(document []byte, wallpaper, templatePath string) []byte {
+	if !httpsURL(wallpaper) {
+		return document
+	}
+	script := `<script id="nezha-komari-market-wallpaper">;(()=>{const wallpaper=` +
+		fmt.Sprintf("%q", wallpaper) + `;Object.defineProperty(window,'CustomBackgroundImage',{configurable:false,enumerable:true,writable:false,value:wallpaper});Object.defineProperty(window,'CustomMobileBackgroundImage',{configurable:false,enumerable:true,writable:false,value:wallpaper});window.__NEZHA_KOMARI_MARKET_THEME__=` +
+		fmt.Sprintf("%q", html.EscapeString(templatePath)) + `;})();</script>`
+	text := string(document)
+	if pos := strings.Index(text, "</head>"); pos >= 0 {
+		return []byte(text[:pos] + script + text[pos:])
+	}
+	return append([]byte(script), document...)
+}

--- a/service/singleton/komari_theme_market_init_test.go
+++ b/service/singleton/komari_theme_market_init_test.go
@@ -1,0 +1,38 @@
+package singleton
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitFrontendTemplatesLoadsFutureCatalogEntriesFromConfiguredCache(t *testing.T) {
+	dir := t.TempDir()
+	cache := filepath.Join(dir, "market.json")
+	catalog := `{"schema":1,"themes":[{"name":"Future Theme","short":"future-theme","version":"9.1","author":"Future Author","url":"https://github.com/example/future","preview":"https://cdn.example/future.webp","download":"https://github.com/example/future/releases/download/v9.1/theme.zip","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}`
+	require.NoError(t, os.WriteFile(cache, []byte(catalog), 0o600))
+	t.Setenv("NZ_KOMARI_THEME_MARKET_URL", "https://127.0.0.1.invalid/catalog.json")
+	t.Setenv("NZ_KOMARI_THEME_MARKET_CACHE", cache)
+
+	originalTemplates := FrontendTemplates
+	originalWallpapers := KomariThemeWallpapers
+	originalCatalog := KomariThemeCatalog
+	t.Cleanup(func() {
+		FrontendTemplates = originalTemplates
+		KomariThemeWallpapers = originalWallpapers
+		KomariThemeCatalog = originalCatalog
+	})
+
+	require.NoError(t, InitFrontendTemplates())
+	var found bool
+	for _, item := range FrontendTemplates {
+		if item.Path == "komari-market-future-theme" {
+			found = true
+			require.Equal(t, "Future Theme", item.Name)
+		}
+	}
+	require.True(t, found)
+	require.Equal(t, "https://cdn.example/future.webp", KomariThemeWallpapers["komari-market-future-theme"])
+}

--- a/service/singleton/komari_theme_market_test.go
+++ b/service/singleton/komari_theme_market_test.go
@@ -1,0 +1,78 @@
+package singleton
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKomariThemeMarketCreatesTemplatesWithoutHardcodedNames(t *testing.T) {
+	catalog := `{"schema":1,"themes":[
+		{"name":{"zh-CN":"未来主题","en":"Future Theme"},"short":"future-theme","version":"9.1.0","author":{"en":"Future Author"},"url":"https://github.com/example/future","preview":"https://cdn.example/future.webp","download":"https://github.com/example/future/releases/download/v9.1.0/theme.zip","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{"name":"Second Theme","short":"SECOND Theme","version":"1.0","author":"Author","url":"https://github.com/example/second","preview":"https://cdn.example/second.png","download":"https://github.com/example/second/releases/download/v1/theme.zip","sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+	]}`
+
+	templates, themes, err := parseKomariThemeMarket(strings.NewReader(catalog))
+	require.NoError(t, err)
+	require.Len(t, templates, 2)
+	byPath := make(map[string]struct {
+		name      string
+		wallpaper string
+	})
+	for _, item := range templates {
+		byPath[item.Path] = struct {
+			name      string
+			wallpaper string
+		}{item.Name, themes[item.Path].Preview}
+	}
+	require.Equal(t, "未来主题", byPath["komari-market-future-theme"].name)
+	require.Equal(t, "https://cdn.example/future.webp", byPath["komari-market-future-theme"].wallpaper)
+	require.Contains(t, byPath, "komari-market-second-theme")
+}
+
+func TestParseKomariThemeMarketRejectsUnsafeOrIncompleteEntries(t *testing.T) {
+	catalog := `{"schema":1,"themes":[
+		{"name":"Unsafe","short":"unsafe","version":"1","author":"x","url":"http://example.com/repo","preview":"javascript:alert(1)","download":"https://example.com/a.zip","sha256":"bad"},
+		{"name":"Valid","short":"valid","version":"1","author":"x","url":"https://github.com/example/valid","preview":"https://cdn.example/valid.webp","download":"https://github.com/example/valid/releases/download/v1/a.zip","sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+	]}`
+
+	templates, themes, err := parseKomariThemeMarket(strings.NewReader(catalog))
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "komari-market-valid", templates[0].Path)
+	require.Len(t, themes, 1)
+}
+
+func TestParseKomariThemeMarketPreservesDownloadAndDigestForRuntimeInstall(t *testing.T) {
+	catalog := `{"schema":1,"themes":[{"name":"Future","short":"future","version":"1","author":"A","url":"https://github.com/example/future","preview":"https://cdn.example/preview.png","download":"https://github.com/example/future/releases/download/v1/theme.zip","sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}`
+	templates, themes, err := parseKomariThemeMarket(strings.NewReader(catalog))
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	meta := themes[templates[0].Path]
+	require.Equal(t, "https://github.com/example/future/releases/download/v1/theme.zip", meta.Download)
+	require.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", meta.SHA256)
+	require.Equal(t, "future", meta.Short)
+}
+
+func TestKomariTemplateResolutionUsesOfficialFrontendAndCatalogWallpaper(t *testing.T) {
+	KomariThemeWallpapers = map[string]string{"komari-market-future": "https://cdn.example/future.webp"}
+	t.Cleanup(func() { KomariThemeWallpapers = nil })
+
+	root, wallpaper, ok := ResolveKomariFrontendTemplate("komari-market-future")
+	require.True(t, ok)
+	require.Equal(t, "user-dist", root)
+	require.Equal(t, "https://cdn.example/future.webp", wallpaper)
+
+	_, _, ok = ResolveKomariFrontendTemplate("user-dist")
+	require.False(t, ok)
+}
+
+func TestInjectKomariWallpaperLocksOnlyBackgroundVariables(t *testing.T) {
+	html := []byte(`<html><head></head><body></body></html>`)
+	out := string(injectKomariWallpaper(html, "https://cdn.example/future.webp", "komari-market-future"))
+	require.Contains(t, out, "Object.defineProperty(window,'CustomBackgroundImage'")
+	require.Contains(t, out, "https://cdn.example/future.webp")
+	require.Contains(t, out, "komari-market-future")
+	require.NotContains(t, out, "DisableAnimatedMan")
+}

--- a/service/singleton/singleton.go
+++ b/service/singleton/singleton.go
@@ -70,10 +70,12 @@ func LoadSingleton(bus chan<- *model.Service) (err error) {
 
 // InitFrontendTemplates 从内置文件中加载FrontendTemplates
 func InitFrontendTemplates() error {
-	err := yaml.Unmarshal(frontendTemplatesYAML, &FrontendTemplates)
-	if err != nil {
+	var builtins []model.FrontendTemplate
+	if err := yaml.Unmarshal(frontendTemplatesYAML, &builtins); err != nil {
 		return err
 	}
+	FrontendTemplates = appendKomariThemeMarketTemplates(builtins)
+	go syncKomariThemes()
 	return nil
 }
 


### PR DESCRIPTION
TLDR：让哪吒 dashboard 可以直接加载 komari theme-market 的真实主题包，兼容komari生态，并用只读浏览器兼容层把哪吒公开数据转换为 komari 主题需要的接口。主题包不修改，登录统一回到哪吒 /dashboard。

这次只包含 komari 主题相关更新。

主题列表从 theme-market 动态读取，未来新增主题不需要继续硬编码。下载主题时验证 SHA256，限制文件数量、压缩包与解压大小，并阻止路径穿越和符号链接。远端目录失败时使用本地缓存和内置快照

选中主题后直接服务其真实 dist。兼容层支持 fetch、XMLHttpRequest、JSON-RPC HTTP、JSON-RPC WebSocket 和旧版 /api/clients WebSocket，并转换节点信息、实时 CPU、内存、磁盘、网络、连接数、进程数、运行时间及部分历史指标。管理、终端、文件和命令执行等写接口不会模拟

komari 主题中的 /admin、/admin/login、/login 和常见登录按钮会进入哪吒原登录入口 /dashboard。还兼容主题 manifest 路径、dist 路径、国家旗帜和系统图标，并限制历史指标并发，避免大规模节点下产生过量请求

没有修改任何第三方主题包的内容，确保今后的兼容性
